### PR TITLE
decisionengine_modules/NERSC: Added retry loop for NERSC API Calls

### DIFF
--- a/NERSC/sources/NerscAllocationInfo.py
+++ b/NERSC/sources/NerscAllocationInfo.py
@@ -33,10 +33,10 @@ class NerscAllocationInfo(Source.Source):
         self.pandas_frame = None
         self.max_retries = config.get("max_retries", _MAX_RETRIES)
         self.retry_backoff_factor = config.get("retry_backoff_factor", _RETRY_BACKOFF_FACTOR)
-        self.newt = newt.Newt(config.get('passwd_file'),
-                              num_retries=self.max_retries,
-                              retry_backoff_factor=self.retry_backoff_factor
-                             )
+        self.newt = newt.Newt(
+            config.get('passwd_file'),
+            num_retries=self.max_retries,
+            retry_backoff_factor=self.retry_backoff_factor)
         self.logger = logging.getLogger()
 
     def send_query(self):

--- a/NERSC/sources/NerscAllocationInfo.py
+++ b/NERSC/sources/NerscAllocationInfo.py
@@ -12,6 +12,9 @@ import logging
 
 PRODUCES = ['Nersc_Allocation_Info']
 
+_MAX_RETRIES = 10
+_RETRY_BACKOFF_FACTOR = 1
+
 
 class NerscAllocationInfo(Source.Source):
 
@@ -28,7 +31,12 @@ class NerscAllocationInfo(Source.Source):
 
         self.raw_results = None
         self.pandas_frame = None
-        self.newt = newt.Newt(config.get('passwd_file'))
+        self.max_retries = config.get("max_retries", _MAX_RETRIES)
+        self.retry_backoff_factor = config.get("retry_backoff_factor", _RETRY_BACKOFF_FACTOR)
+        self.newt = newt.Newt(config.get('passwd_file'),
+                              num_retries=self.max_retries,
+                              retry_backoff_factor=self.retry_backoff_factor
+                             )
         self.logger = logging.getLogger()
 
     def send_query(self):
@@ -95,6 +103,8 @@ def module_config_template():
             'name': 'NerscAllocationInfo',
             'parameters': {
                 'passwd_file': '/path/to/password_file',
+                'max_retries': 10,
+                'retry_backoff_factor': 1,
                 'constraints': {
                     'usernames': ['user1', 'user2'],
                     'newt_keys': {

--- a/NERSC/sources/NerscJobInfo.py
+++ b/NERSC/sources/NerscJobInfo.py
@@ -31,10 +31,10 @@ class NerscJobInfo(Source.Source):
             raise RuntimeError('constraints should be a dict')
         self.max_retries = config.get("max_retries", _MAX_RETRIES)
         self.retry_backoff_factor = config.get("retry_backoff_factor", _RETRY_BACKOFF_FACTOR)
-        self.newt = newt.Newt(config.get('passwd_file'),
-                              num_retries=self.max_retries,
-                              retry_backoff_factor=self.retry_backoff_factor
-                             )
+        self.newt = newt.Newt(
+            config.get('passwd_file'),
+            num_retries=self.max_retries,
+            retry_backoff_factor=self.retry_backoff_factor)
         self.logger = logging.getLogger()
 
     def acquire(self):

--- a/NERSC/sources/NerscJobInfo.py
+++ b/NERSC/sources/NerscJobInfo.py
@@ -1,22 +1,22 @@
-"""
-Get job info from Nersc
+""" Get job info from Nersc
 """
 import argparse
+import logging
 import pprint
 import pandas as pd
-import time
 
 from decisionengine.framework.modules import Source
 from decisionengine_modules.NERSC.util import newt
-import logging
 
 PRODUCES = ['Nersc_Job_Info']
 
 _MAX_RETRIES = 10
-_RETRY_TIMEOUT = 10
+_RETRY_BACKOFF_FACTOR = 1
 # TODO this is a default column list and needs to be overriden from configuration
-COLUMN_LIST = ['status', 'repo', 'rank_bf', 'qos', 'name', 'timeuse', 'hostname', 'jobid', 'queue',
-               'submittime', 'reason', 'source', 'memory', 'nodes', 'rank_p', 'timereq', 'procs', 'user']
+COLUMN_LIST = ['status', 'repo', 'rank_bf', 'qos', 'name', 'timeuse',
+               'hostname', 'jobid', 'queue', 'submittime', 'reason',
+               'source', 'memory', 'nodes', 'rank_p', 'timereq',
+               'procs', 'user']
 
 
 class NerscJobInfo(Source.Source):
@@ -29,15 +29,19 @@ class NerscJobInfo(Source.Source):
         self.constraints = config.get('constraints')
         if not isinstance(self.constraints, dict):
             raise RuntimeError('constraints should be a dict')
-        self.newt = newt.Newt(config.get('passwd_file'))
-        self.logger = logging.getLogger()
         self.max_retries = config.get("max_retries", _MAX_RETRIES)
-        self.retry_timeout = config.get("retry_timeout", _RETRY_TIMEOUT)
+        self.retry_backoff_factor = config.get("retry_backoff_factor", _RETRY_BACKOFF_FACTOR)
+        self.newt = newt.Newt(config.get('passwd_file'),
+                              num_retries=self.max_retries,
+                              retry_backoff_factor=self.retry_backoff_factor
+                             )
+        self.logger = logging.getLogger()
 
-    def _acquire(self):
+    def acquire(self):
         """
-        Helper method that does heavy lifting.
-        Called from acquire
+        Method to be called from Task Manager.
+        redefines acquire from Source.py.
+        Acquire NERSC job info and return as pandas frame
         :return: `dict`
         """
         raw_results = []
@@ -74,27 +78,6 @@ class NerscJobInfo(Source.Source):
         """
         return PRODUCES
 
-    def acquire(self):
-        """
-        Method to be called from Task Manager.
-        redefines acquire from Source.py.
-        Acquire NERSC job info and return as pandas frame
-        :rtype: :obj:`~pd.DataFrame`
-        """
-        tries = 0
-        while True:
-            try:
-                return self._acquire()
-            except RuntimeError:
-                raise
-            except Exception as e:
-                if tries < self.max_retries:
-                    tries += 1
-                    time.sleep(self.retry_timeout)
-                    continue
-                else:
-                    raise RuntimeError(str(e))
-
 
 def module_config_template():
     """
@@ -107,8 +90,8 @@ def module_config_template():
             'name': 'NerscJobInfo',
             'parameters': {
                 'passwd_file': '/path/to/password_file',
+                'retry_backoff_factor': 1,
                 'max_retries': 10,
-                'retry_timeout': 10,
                 'constraints': {
                     'machines': ["edison", "cori"],
                     'newt_keys': {

--- a/NERSC/util/newt.py
+++ b/NERSC/util/newt.py
@@ -48,10 +48,9 @@ class Newt(object):
         """
         retry = Retry(
             status=self.num_retries,
-            status_forcelist=[500,],
+            status_forcelist=[500, ],
             backoff_factor=self.retry_backoff_factor,
-            method_whitelist=False
-            )
+            method_whitelist=False)
         retry_adapter = HTTPAdapter(max_retries=retry)
         self.session.mount(self.newt_base_url, retry_adapter)
 

--- a/NERSC/util/newt.py
+++ b/NERSC/util/newt.py
@@ -6,6 +6,8 @@ from copy import deepcopy
 import os
 import time
 import requests
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 
 """
 Newt base URL. When not specified in constructor this
@@ -16,7 +18,8 @@ _NEWT_BASE_URL = "https://newt.nersc.gov/newt/"
 
 class Newt(object):
 
-    def __init__(self, password_file, newt_base_url=None):
+    def __init__(self, password_file, newt_base_url=None, num_retries=0,
+                 retry_backoff_factor=0):
         """
         Constructor that takes path to password file and
         optional Newt base URL
@@ -33,7 +36,24 @@ class Newt(object):
         if not self.newt_base_url.endswith("/"):
             self.newt_base_url += "/"
         self.session = requests.Session()
+        self.num_retries = num_retries
+        self.retry_backoff_factor = retry_backoff_factor
         self.expiration_time = time.time()
+        self._add_retries_to_session()
+
+    def _add_retries_to_session(self):
+        """
+        Adds retries to requests Session for requests to NEWT URLs
+        :return: void
+        """
+        retry = Retry(
+            status=self.num_retries,
+            status_forcelist=[500,],
+            backoff_factor=self.retry_backoff_factor,
+            method_whitelist=False
+            )
+        retry_adapter = HTTPAdapter(max_retries=retry)
+        self.session.mount(self.newt_base_url, retry_adapter)
 
     def _login(self):
         """
@@ -46,6 +66,7 @@ class Newt(object):
             with open(self.password_file) as f:
                 postfields = "&".join([line[:-1].strip()
                                        for line in f.readlines()])
+
             r = self.session.post(login_url, data=postfields)
             r.raise_for_status()
             response_dict = r.json()

--- a/NERSC/util/newt.py
+++ b/NERSC/util/newt.py
@@ -7,7 +7,7 @@ import os
 import time
 import requests
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
+from urllib3.util.retry import Retry
 
 """
 Newt base URL. When not specified in constructor this

--- a/build/scripts/utils.sh
+++ b/build/scripts/utils.sh
@@ -27,7 +27,7 @@ setup_python_venv() {
 
     source $VENV/bin/activate
 
-    pip_packages="pylint pycodestyle pytest mock tabulate pandas google-api-python-client boto boto3 gcs_oauth2_boto_plugin"
+    pip_packages="pylint pycodestyle pytest mock tabulate pandas google-api-python-client boto boto3 gcs_oauth2_boto_plugin urllib3"
     echo "Installing $pip_packages ..."
     pip install --quiet $pip_packages
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
Use urllib3 Retry class to automate retries for requests sent to NERSC

  RB : https://fermicloud140.fnal.gov/reviews/r/119/

**Note** that this allows for a config change:

The new configuration keys, 'max_retries', and 'retry_backoff_factor' will go in the NERSC channel configs, like so:

 'NerscAllocationInfo' : {
      'module': 'decisionengine_modules.NERSC.sources.NerscAllocationInfo',
      'name': 'NerscAllocationInfo',
      'parameters' : {
                      'max_retries': 5,
                      'retry_backoff_factor': 1,
                      'constraints': {
                                    'usernames': ["timm","user2"],
                                    'newt_keys': {
                                    'rname': ['m2612','m2696','m2015'],
                                    'repo_type': ["REPO", ],
                                    }
                }
            },
            "schedule" : 320,
        },

These changes are not required, and the new code is backward-compatible with the old config.