### PR TITLE
add jsonnet dependency in build/scripts/utils.sh for unit tests

### DIFF
--- a/build/scripts/utils.sh
+++ b/build/scripts/utils.sh
@@ -27,7 +27,7 @@ setup_python_venv() {
 
     source $VENV/bin/activate
 
-    pip_packages="pylint pycodestyle pytest mock tabulate pandas google-api-python-client boto boto3 gcs_oauth2_boto_plugin urllib3"
+    pip_packages="pylint pycodestyle pytest mock tabulate pandas google-api-python-client boto boto3 gcs_oauth2_boto_plugin urllib3 jsonnet"
     echo "Installing $pip_packages ..."
     pip install --quiet $pip_packages
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
unit tests run inside python virtualenv that is set up using
build/scripts/utils.sh
Added jsonnet module as dependency to properly setup unit tests environment for decision_modules repository.

RB: https://fermicloud140.fnal.gov/reviews/r/173/