### PR TITLE
decisionengine_modules/NerscAllocationInfo: Can run NerscAllocationInfo.py without running DE

### DIFF
--- a/NERSC/sources/NerscAllocationInfo.py
+++ b/NERSC/sources/NerscAllocationInfo.py
@@ -32,7 +32,8 @@ class NerscAllocationInfo(Source.Source):
         self.raw_results = None
         self.pandas_frame = None
         self.max_retries = config.get("max_retries", _MAX_RETRIES)
-        self.retry_backoff_factor = config.get("retry_backoff_factor", _RETRY_BACKOFF_FACTOR)
+        self.retry_backoff_factor = config.get("retry_backoff_factor",
+                                               _RETRY_BACKOFF_FACTOR)
         self.newt = newt.Newt(
             config.get('passwd_file'),
             num_retries=self.max_retries,
@@ -138,12 +139,26 @@ def main():
         '--configinfo',
         action='store_true',
         help='prints config template along with produces and consumes info')
+    parser.add_argument(
+        '--acquire-with-config',
+        action='store',
+        metavar='CONFIG_FILE',
+        help='Tries to contact NERSC with the provided config file and pulls '
+        'data according to config')
     args = parser.parse_args()
 
     if args.configtemplate:
         module_config_template()
     elif args.configinfo:
         module_config_info()
+    elif args.acquire_with_config:
+        from ast import literal_eval
+        with open(args.acquire_with_config, 'r') as f:
+            config_string = "".join(f.readlines())
+            config = literal_eval(config_string)
+        n = NerscAllocationInfo(config['sources']['NerscAllocationInfo']
+                                ['parameters'])
+        print(n.acquire())
     else:
         pass
 

--- a/tests/test_NerscAllocationInfo.py
+++ b/tests/test_NerscAllocationInfo.py
@@ -25,7 +25,13 @@ CONFIG = {
 }
 
 PRODUCES = ["Nersc_Allocation_Info"]
-EXPECTED_PANDAS_DFRAME = pandas.DataFrame([{u'uid': 72048, u'firstname': u'Steven', u'middlename': u'C', u'projectId': 54807, u'currentAlloc': 374400000000.0, u'userAlloc': 0.0, u'repoType': u'REPO', u'repoName': u'm2612', u'lastname': u'Timm', u'userAllocPct': 2.0, u'usedAlloc': 560.0, u'name': u'timm'}])
+EXPECTED_PANDAS_DFRAME = pandas.DataFrame(
+    [{u'uid': 72048, u'firstname': u'Steven', u'middlename': u'C',
+        u'projectId': 54807, u'currentAlloc': 374400000000.0,
+        u'userAlloc': 0.0, u'repoType': u'REPO', u'repoName': u'm2612',
+        u'lastname': u'Timm', u'userAllocPct': 2.0, u'usedAlloc': 560.0,
+        u'name': u'timm'}])
+
 
 class TestNerscAllocationInfo:
 


### PR DESCRIPTION
You can pass NerscAllocationInfo.py a config file with the relevant dict (as shown by the --configinfo flag), and it will run the acquire() method, querying NERSC.

RB : https://fermicloud140.fnal.gov/reviews/r/182/

This was a request by Steve Timm (#246 ) to add functionality to NerscAllocationInfo.py to allow it be run standalone (outside of the entire DE running).  
