### PR TITLE
Added initial unit test for glide_frontend_element.py

### DIFF
--- a/.github/actions/unittest-in-sl7-docker/Dockerfile
+++ b/.github/actions/unittest-in-sl7-docker/Dockerfile
@@ -1,7 +1,9 @@
 FROM hepcloud/decision-engine-ci
 # Adding dependencies for GlideinWMS
-RUN yum install -v python36-m2crypto python-rrdtool osg-wn-client vo-client voms-clients-cpp \
-  python36-ldap3 python36-jwt PyYAML && yum clean all
+#RUN yum install -y python36-m2crypto python-rrdtool osg-wn-client vo-client voms-clients-cpp \
+#  python36-ldap3 python36-jwt PyYAML
+RUN yum install -y python36-m2crypto python-rrdtool  python36-ldap3 python36-jwt PyYAML
+RUN yum clean all
 # User and test setup
 COPY entrypoint.sh /entrypoint.sh
 RUN groupadd -g 115 decision-engine-ci

--- a/.github/actions/unittest-in-sl7-docker/Dockerfile
+++ b/.github/actions/unittest-in-sl7-docker/Dockerfile
@@ -2,8 +2,6 @@ FROM hepcloud/decision-engine-ci
 # Adding dependencies for GlideinWMS
 RUN yum install -y python36-m2crypto python-rrdtool osg-wn-client vo-client voms-clients-cpp \
   python36-ldap3 python36-jwt PyYAML && yum clean all
-#RUN yum install -y python36-m2crypto python-rrdtool  python36-ldap3 python36-jwt PyYAML
-#RUN yum clean all
 # User and test setup
 COPY entrypoint.sh /entrypoint.sh
 RUN groupadd -g 115 decision-engine-ci

--- a/.github/actions/unittest-in-sl7-docker/Dockerfile
+++ b/.github/actions/unittest-in-sl7-docker/Dockerfile
@@ -1,4 +1,8 @@
 FROM hepcloud/decision-engine-ci
+# Adding dependencies for GlideinWMS
+RUN yum install -v python36-m2crypto python-rrdtool osg-wn-client vo-client voms-clients-cpp \
+  python36-ldap3 python36-jwt PyYAML && yum clean all
+# User and test setup
 COPY entrypoint.sh /entrypoint.sh
 RUN groupadd -g 115 decision-engine-ci
 RUN useradd -u 1001 -g 115 decision-engine-ci

--- a/.github/actions/unittest-in-sl7-docker/Dockerfile
+++ b/.github/actions/unittest-in-sl7-docker/Dockerfile
@@ -1,9 +1,9 @@
 FROM hepcloud/decision-engine-ci
 # Adding dependencies for GlideinWMS
-#RUN yum install -y python36-m2crypto python-rrdtool osg-wn-client vo-client voms-clients-cpp \
-#  python36-ldap3 python36-jwt PyYAML
-RUN yum install -y python36-m2crypto python-rrdtool  python36-ldap3 python36-jwt PyYAML
-RUN yum clean all
+RUN yum install -y python36-m2crypto python-rrdtool osg-wn-client vo-client voms-clients-cpp \
+  python36-ldap3 python36-jwt PyYAML && yum clean all
+#RUN yum install -y python36-m2crypto python-rrdtool  python36-ldap3 python36-jwt PyYAML
+#RUN yum clean all
 # User and test setup
 COPY entrypoint.sh /entrypoint.sh
 RUN groupadd -g 115 decision-engine-ci

--- a/.github/actions/unittest-in-sl7-docker/Dockerfile.jenkins
+++ b/.github/actions/unittest-in-sl7-docker/Dockerfile.jenkins
@@ -1,7 +1,9 @@
 FROM hepcloud/decision-engine-ci
 # Adding dependencies for GlideinWMS
-RUN yum install -v python36-m2crypto python-rrdtool osg-wn-client vo-client voms-clients-cpp \
-  python36-ldap3 python36-jwt PyYAML && yum clean all
+#RUN yum install -y python36-m2crypto python-rrdtool osg-wn-client vo-client voms-clients-cpp \
+#  python36-ldap3 python36-jwt PyYAML
+RUN yum install -y python36-m2crypto python-rrdtool  python36-ldap3 python36-jwt PyYAML
+RUN yum clean all
 # User and test setup
 COPY entrypoint.sh /entrypoint.sh
 RUN groupadd -g 500 decision-engine-ci

--- a/.github/actions/unittest-in-sl7-docker/Dockerfile.jenkins
+++ b/.github/actions/unittest-in-sl7-docker/Dockerfile.jenkins
@@ -1,4 +1,8 @@
 FROM hepcloud/decision-engine-ci
+# Adding dependencies for GlideinWMS
+RUN yum install -v python36-m2crypto python-rrdtool osg-wn-client vo-client voms-clients-cpp \
+  python36-ldap3 python36-jwt PyYAML && yum clean all
+# User and test setup
 COPY entrypoint.sh /entrypoint.sh
 RUN groupadd -g 500 decision-engine-ci
 RUN useradd -u 500 -g 500 decision-engine-ci

--- a/.github/actions/unittest-in-sl7-docker/Dockerfile.jenkins
+++ b/.github/actions/unittest-in-sl7-docker/Dockerfile.jenkins
@@ -1,9 +1,7 @@
 FROM hepcloud/decision-engine-ci
 # Adding dependencies for GlideinWMS
-#RUN yum install -y python36-m2crypto python-rrdtool osg-wn-client vo-client voms-clients-cpp \
-#  python36-ldap3 python36-jwt PyYAML
-RUN yum install -y python36-m2crypto python-rrdtool  python36-ldap3 python36-jwt PyYAML
-RUN yum clean all
+RUN yum install -y python36-m2crypto python-rrdtool osg-wn-client vo-client voms-clients-cpp \
+  python36-ldap3 python36-jwt PyYAML && yum clean all
 # User and test setup
 COPY entrypoint.sh /entrypoint.sh
 RUN groupadd -g 500 decision-engine-ci

--- a/.github/actions/unittest-in-sl7-docker/entrypoint.sh
+++ b/.github/actions/unittest-in-sl7-docker/entrypoint.sh
@@ -13,6 +13,12 @@ make liblinks
 cd -
 export PYTHONPATH=$PWD:$PYTHONPATH
 source venv/bin/activate
+# MMDB
+echo "MMDB Python (`which python`): `python --version`"
+echo "MMDB M2Crypto: `yum list *m2crypto*`"
+echo "MMDB M2Crypto python: `python3 -c "import M2Crypto; print (M2Crypto.__path__)"`"
+echo "MMDB M2Crypto python3: `python3 -c "import M2Crypto; print (M2Crypto.__path__)"`"
+
 pytest -v -l --tb=native decisionengine_modules > pytest.log 2>&1
 status=$?
 cat pytest.log

--- a/.github/actions/unittest-in-sl7-docker/entrypoint.sh
+++ b/.github/actions/unittest-in-sl7-docker/entrypoint.sh
@@ -13,12 +13,6 @@ make liblinks
 cd -
 export PYTHONPATH=$PWD:$PYTHONPATH
 source venv/bin/activate
-# MMDB
-echo "MMDB Python (`which python`): `python --version`"
-echo "MMDB M2Crypto: `yum list *m2crypto*`"
-echo "MMDB M2Crypto python: `python3 -c "import M2Crypto; print (M2Crypto.__path__)"`"
-echo "MMDB M2Crypto python3: `python3 -c "import M2Crypto; print (M2Crypto.__path__)"`"
-
 pytest -v -l --tb=native decisionengine_modules > pytest.log 2>&1
 status=$?
 cat pytest.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,6 +98,12 @@ install:
   - make
   - make liblinks
 
+  # Pull down glideinwms/branch_v3_9
+  - cd $(dirname ${TRAVIS_BUILD_DIR})
+  - git clone https://github.com/glideinWMS/glideinwms.git
+  - cd glideinwms
+  - git checkout branch_v3_9
+
   # pull in any listed python requirements
   - cd ${TRAVIS_BUILD_DIR}/../decisionengine/
   - pip install -r requirements.txt
@@ -105,6 +111,7 @@ install:
   - cd ${TRAVIS_BUILD_DIR}
   - pip install -r requirements.txt
   - pip3 install --index-url https://test.pypi.org/simple --no-deps bill-calculator-hep-mapsacosta==0.0.9
+  - python -m pip install m2crypto
   - pip install coveralls
 
 # Environment variables

--- a/build/scripts/utils.sh
+++ b/build/scripts/utils.sh
@@ -64,7 +64,7 @@ setup_git_product() {
     pwd
     git clone -v $product_git_repo
     # optional $3 is the branch
-    [ -n "$3" ] && ( pwd; ls; cd "$(git_get_directory "$product_git_repo"))"; git checkout $3; )
+    [ -n "$3" ] && ( echo "MMDB (`pwd`):`ls`"; echo "MMDB (`git_get_directory "$product_git_repo"`): `ls "$(git_get_directory "$product_git_repo")"`"; cd $(git_get_directory "$product_git_repo"); git checkout $3; )
 }
 
 

--- a/build/scripts/utils.sh
+++ b/build/scripts/utils.sh
@@ -47,13 +47,16 @@ setup_git_product() {
     wspace=${2:-`pwd`}
     cd $wspace
     git clone $product_git_repo
+    # optional $3 is the branch
+    [ -n "$3" ] && git checkout $3
 }
 
 
 setup_glideinwms() {
     dir=$1
+    # Python 3 version of GlideinWMS is in branch_v3_9 of https://github.com/glideinWMS/glideinwms.git
     glideinwms_git_repo="https://github.com/glideinWMS/glideinwms.git"
-    setup_git_product "$glideinwms_git_repo" $dir
+    setup_git_product "$glideinwms_git_repo" $dir branch_v3_9
 }
 
 

--- a/build/scripts/utils.sh
+++ b/build/scripts/utils.sh
@@ -22,12 +22,12 @@ setup_python_venv() {
     PIP_EXE=pip
 
     if [ ! -d $VENV ] ; then
-      $VIRTUALENV_EXE $VENV
+      $VIRTUALENV_EXE --system-site-packages $VENV
     fi
 
     source $VENV/bin/activate
 
-    pip_packages="pylint pycodestyle pytest mock tabulate pandas google-api-python-client boto boto3 gcs_oauth2_boto_plugin urllib3 jsonnet"
+    pip_packages="pylint pycodestyle pytest mock tabulate pandas google-api-python-client boto boto3 gcs_oauth2_boto_plugin urllib3 jsonnet m2crypto"
     echo "Installing $pip_packages ..."
     pip install --quiet $pip_packages
     if [ $? -ne 0 ]; then

--- a/build/scripts/utils.sh
+++ b/build/scripts/utils.sh
@@ -62,9 +62,9 @@ setup_git_product() {
     wspace=${2:-`pwd`}
     cd $wspace
     pwd
-    git clone -v $product_git_repo
+    git clone $product_git_repo
     # optional $3 is the branch
-    [ -n "$3" ] && ( echo "MMDB (`pwd`):`ls`"; echo "MMDB (`git_get_directory "$product_git_repo"`): `ls "$(git_get_directory "$product_git_repo")"`"; cd $(git_get_directory "$product_git_repo"); git checkout $3; )
+    [ -n "$3" ] && ( cd $(git_get_directory "$product_git_repo"); git checkout $3; )
 }
 
 

--- a/build/scripts/utils.sh
+++ b/build/scripts/utils.sh
@@ -61,9 +61,10 @@ setup_git_product() {
     product_git_repo=$1
     wspace=${2:-`pwd`}
     cd $wspace
-    git clone $product_git_repo
+    pwd
+    git clone -v $product_git_repo
     # optional $3 is the branch
-    [ -n "$3" ] && ( cd "$(git_get_directory "$product_git_repo"))"; git checkout $3; )
+    [ -n "$3" ] && ( pwd; ls; cd "$(git_get_directory "$product_git_repo"))"; git checkout $3; )
 }
 
 

--- a/build/scripts/utils.sh
+++ b/build/scripts/utils.sh
@@ -42,13 +42,28 @@ setup_python_venv() {
 }
 
 
+git_get_directory() {
+    # Derive one from the repository name
+    # Try using "humanish" part of source repo if user didn't specify one
+    # adapted from:
+    # https://github.com/git/git/blob/cb9d69ad638fe34d214cf9cb2850e38be6e6d639/contrib/examples/git-clone.sh#L224
+    # 1 - git URL or bundle path
+    if [ -f "$1" ]; then
+        # Cloning from a bundle
+        echo "$1" | sed -e 's|/*\.bundle$||' -e 's|.*/||g'
+    else
+        echo "$1" | sed -e 's|/$||' -e 's|:*/*\.git$||' -e 's|.*[/:]||g'
+    fi
+}
+
+
 setup_git_product() {
     product_git_repo=$1
     wspace=${2:-`pwd`}
     cd $wspace
     git clone $product_git_repo
     # optional $3 is the branch
-    [ -n "$3" ] && git checkout $3
+    [ -n "$3" ] && ( cd "$(git_get_directory "$product_git_repo"))"; git checkout $3; )
 }
 
 

--- a/build/scripts/utils.sh
+++ b/build/scripts/utils.sh
@@ -61,7 +61,6 @@ setup_git_product() {
     product_git_repo=$1
     wspace=${2:-`pwd`}
     cd $wspace
-    pwd
     git clone $product_git_repo
     # optional $3 is the branch
     [ -n "$3" ] && ( cd $(git_get_directory "$product_git_repo"); git checkout $3; )

--- a/tests/glideinwms/test_glide_frontend_element.py
+++ b/tests/glideinwms/test_glide_frontend_element.py
@@ -1,5 +1,7 @@
 import os
 
+# These modules are not used here, adding the import to test for the presence
+# of modules used in glide_frontend_element
 gwms_modules_available = True
 try:
     from glideinwms.frontend import glideinFrontendConfig
@@ -16,65 +18,77 @@ def test_glideinwms_import():
     assert gwms_modules_available
 
 
-FRONTEND_CFG = {'frontend': {'frontend_name': 'hepcsvc00-fnal-gov_hepcloud_decisionengine',
-                             'monitoring_web_url': 'http://hepcsvc00.fnal.gov:8319/vofrontend/monitor',
-                             'web_url': 'http://hepcsvc00.fnal.gov:8319/vofrontend/stage',
-                             'workdir': '/var/lib/gwms-frontend/vofrontend'},
-                'group': {'cms': {'ProxyCreationScripts': {},
-                       'ProxyKeyFiles': {u'/etc/gwms-frontend/credentials/hepcloud_fermilab_accesskey': u'/etc/gwms-frontend/credentials/hepcloud_fermilab_secretkey'},
-                       'ProxyPilotFiles': {u'/etc/gwms-frontend/credentials/hepcloud_fermilab_accesskey': u'/etc/gwms-frontend/proxies/cloud_proxy'},
-                       'ProxyProjectIds': {u'/etc/gwms-frontend/proxies/cms_proxy': u'unb000'},
-                       'ProxyRemoteUsernames': {},
-                       'ProxySecurityClasses': {u'/etc/gwms-frontend/credentials/hepcloud_fermilab_accesskey': u'frontend',
-                                                u'/etc/gwms-frontend/proxies/cms_proxy': u'frontend'},
-                       'ProxyTrustDomains': {u'/etc/gwms-frontend/credentials/hepcloud_fermilab_accesskey': u'HEPCloud_AWS_us-east-1',
-                                             u'/etc/gwms-frontend/proxies/cms_proxy': u'grid'},
-                       'ProxyTypes': {u'/etc/gwms-frontend/credentials/hepcloud_fermilab_accesskey': u'key_pair+vm_id',
-                                      u'/etc/gwms-frontend/proxies/cms_proxy': u'grid_proxy+project_id'},
-                       'ProxyUpdateFrequency': {},
-                       'ProxyVMIdFname': {},
-                       'ProxyVMIds': {u'/etc/gwms-frontend/credentials/hepcloud_fermilab_accesskey': u'ami-00000000000'},
-                       'ProxyVMTypeFname': {},
-                       'ProxyVMTypes': {},
-                       'classad_proxy': '/etc/gwms-frontend/proxies/fe_proxy',
-                       'condor_config': '/var/lib/gwms-frontend/vofrontend/frontend.condor_config',
-                       'condor_mapfile': '/var/lib/gwms-frontend/vofrontend/group_cms_all/group.mapfile',
-                       'curb_vms_idle': 4500,
-                       'factory_collectors': [(u'cmssrv200.fnal.gov',
-                                               u'gfactory@cmssrv200.fnal.gov',
-                                               u'hepcloudsvc00@cmssrv200.fnal.gov')],
-                       'fe_total_curb_glideins': 167000,
-                       'fe_total_curb_vms_idle': 25000,
-                       'fe_total_max_glideins': 170000,
-                       'fe_total_max_vms_idle': 35000,
-                       'fraction_running': 3.0,
-                       'global_total_curb_glideins': 167000,
-                       'global_total_curb_vms_idle': 25000,
-                       'global_total_max_glideins': 170000,
-                       'global_total_max_vms_idle': 35000,
-                       'max_idle': 12800,
-                       'max_matchmakers': 3,
-                       'max_running': '40000',
-                       'max_vms_idle': 5000,
-                       'min_running': '0',
-                       'proxies': [u'/etc/gwms-frontend/proxies/cms_proxy',
-                                   u'/etc/gwms-frontend/credentials/hepcloud_fermilab_accesskey'],
-                       'proxy_selection_plugin': 'ProxyAll',
-                       'reserve_idle': 100,
-                       'schedds': ['cmssrv270.fnal.gov',
-                                   'cmssrv277.fnal.gov'],
-                       'security_name': 'hepcloudsvc00',
-                       'sign_descript': {'frontend_descript_fname': 'description.000000.cfg',
-                                         'frontend_descript_signature': '123000000000a000000000a000000000',
-                                         'group_descript_fname': 'description.000000.cfg',
-                                         'group_descript_signature': '321000000000a000000000a000000000',
-                                         'signature_type': 'sha1'},
-                       'total_curb_glideins': 39000,
-                       'total_curb_vms_idle': 39000,
-                       'total_max_glideins': 40000,
-                       'total_max_vms_idle': 40000,
-                       'web_url': 'http://hepcsvc00.fnal.gov:8319/vofrontend/stage/group_cms',
-                       'workdir': '/var/lib/gwms-frontend/vofrontend/group_cms'}}}
+FRONTEND_CFG = {
+    'frontend': {
+        'frontend_name': 'hepcsvc00-fnal-gov_hepcloud_decisionengine',
+        'monitoring_web_url': 'http://hepcsvc00.fnal.gov:8319/vofrontend/monitor',
+        'web_url': 'http://hepcsvc00.fnal.gov:8319/vofrontend/stage',
+        'workdir': '/var/lib/gwms-frontend/vofrontend'},
+    'group': {
+        'cms': {
+            'ProxyCreationScripts': {},
+            'ProxyKeyFiles': {
+                u'/etc/gwms-frontend/credentials/hepcloud_fermilab_accesskey': u'/etc/gwms-frontend/credentials/hepcloud_fermilab_secretkey'},
+            'ProxyPilotFiles': {
+                u'/etc/gwms-frontend/credentials/hepcloud_fermilab_accesskey': u'/etc/gwms-frontend/proxies/cloud_proxy'},
+            'ProxyProjectIds': {
+                u'/etc/gwms-frontend/proxies/cms_proxy': u'unb000'},
+            'ProxyRemoteUsernames': {},
+            'ProxySecurityClasses': {
+                u'/etc/gwms-frontend/credentials/hepcloud_fermilab_accesskey': u'frontend',
+                u'/etc/gwms-frontend/proxies/cms_proxy': u'frontend'},
+            'ProxyTrustDomains': {
+                u'/etc/gwms-frontend/credentials/hepcloud_fermilab_accesskey': u'HEPCloud_AWS_us-east-1',
+                u'/etc/gwms-frontend/proxies/cms_proxy': u'grid'},
+            'ProxyTypes': {
+                u'/etc/gwms-frontend/credentials/hepcloud_fermilab_accesskey': u'key_pair+vm_id',
+                u'/etc/gwms-frontend/proxies/cms_proxy': u'grid_proxy+project_id'},
+            'ProxyUpdateFrequency': {},
+            'ProxyVMIdFname': {},
+            'ProxyVMIds': {
+                u'/etc/gwms-frontend/credentials/hepcloud_fermilab_accesskey': u'ami-00000000000'},
+            'ProxyVMTypeFname': {},
+            'ProxyVMTypes': {},
+            'classad_proxy': '/etc/gwms-frontend/proxies/fe_proxy',
+            'condor_config': '/var/lib/gwms-frontend/vofrontend/frontend.condor_config',
+            'condor_mapfile': '/var/lib/gwms-frontend/vofrontend/group_cms_all/group.mapfile',
+            'curb_vms_idle': 4500,
+            'factory_collectors': [(u'cmssrv200.fnal.gov',
+                                    u'gfactory@cmssrv200.fnal.gov',
+                                    u'hepcloudsvc00@cmssrv200.fnal.gov')],
+            'fe_total_curb_glideins': 167000,
+            'fe_total_curb_vms_idle': 25000,
+            'fe_total_max_glideins': 170000,
+            'fe_total_max_vms_idle': 35000,
+            'fraction_running': 3.0,
+            'global_total_curb_glideins': 167000,
+            'global_total_curb_vms_idle': 25000,
+            'global_total_max_glideins': 170000,
+            'global_total_max_vms_idle': 35000,
+            'max_idle': 12800,
+            'max_matchmakers': 3,
+            'max_running': '40000',
+            'max_vms_idle': 5000,
+            'min_running': '0',
+            'proxies': [u'/etc/gwms-frontend/proxies/cms_proxy',
+                        u'/etc/gwms-frontend/credentials/hepcloud_fermilab_accesskey'],
+            'proxy_selection_plugin': 'ProxyAll',
+            'reserve_idle': 100,
+            'schedds': ['cmssrv270.fnal.gov',
+                        'cmssrv277.fnal.gov'],
+            'security_name': 'hepcloudsvc00',
+            'sign_descript': {
+                'frontend_descript_fname': 'description.000000.cfg',
+                'frontend_descript_signature': '123000000000a000000000a000000000',
+                'group_descript_fname': 'description.000000.cfg',
+                'group_descript_signature': '321000000000a000000000a000000000',
+                'signature_type': 'sha1'},
+            'total_curb_glideins': 39000,
+            'total_curb_vms_idle': 39000,
+            'total_max_glideins': 40000,
+            'total_max_vms_idle': 40000,
+            'web_url': 'http://hepcsvc00.fnal.gov:8319/vofrontend/stage/group_cms',
+            'workdir': '/var/lib/gwms-frontend/vofrontend/group_cms'}}}
 
 
 class TestGlideFrontendElement:
@@ -104,5 +118,3 @@ class TestGlideFrontendElement:
         assert gfe.compute_glidein_max_running({'Idle': 100}, 0, 0) == 115
         assert gfe.compute_glidein_max_running({'Idle': 0}, 0, 0) == 0
         assert gfe.compute_glidein_max_running({'Idle': 0}, 100, 100) == 100
-
-

--- a/tests/glideinwms/test_glide_frontend_element.py
+++ b/tests/glideinwms/test_glide_frontend_element.py
@@ -1,0 +1,108 @@
+import os
+
+gwms_modules_available = True
+try:
+    from glideinwms.frontend import glideinFrontendConfig
+    from glideinwms.frontend import glideinFrontendInterface
+    from glideinwms.frontend import glideinFrontendPlugins
+    from glideinwms.lib import pubCrypto
+except ImportError:
+    gwms_modules_available = False
+
+from decisionengine_modules.glideinwms import glide_frontend_element
+
+
+def test_glideinwms_import():
+    assert gwms_modules_available
+
+
+FRONTEND_CFG = {'frontend': {'frontend_name': 'hepcsvc00-fnal-gov_hepcloud_decisionengine',
+                             'monitoring_web_url': 'http://hepcsvc00.fnal.gov:8319/vofrontend/monitor',
+                             'web_url': 'http://hepcsvc00.fnal.gov:8319/vofrontend/stage',
+                             'workdir': '/var/lib/gwms-frontend/vofrontend'},
+                'group': {'cms': {'ProxyCreationScripts': {},
+                       'ProxyKeyFiles': {u'/etc/gwms-frontend/credentials/hepcloud_fermilab_accesskey': u'/etc/gwms-frontend/credentials/hepcloud_fermilab_secretkey'},
+                       'ProxyPilotFiles': {u'/etc/gwms-frontend/credentials/hepcloud_fermilab_accesskey': u'/etc/gwms-frontend/proxies/cloud_proxy'},
+                       'ProxyProjectIds': {u'/etc/gwms-frontend/proxies/cms_proxy': u'unb000'},
+                       'ProxyRemoteUsernames': {},
+                       'ProxySecurityClasses': {u'/etc/gwms-frontend/credentials/hepcloud_fermilab_accesskey': u'frontend',
+                                                u'/etc/gwms-frontend/proxies/cms_proxy': u'frontend'},
+                       'ProxyTrustDomains': {u'/etc/gwms-frontend/credentials/hepcloud_fermilab_accesskey': u'HEPCloud_AWS_us-east-1',
+                                             u'/etc/gwms-frontend/proxies/cms_proxy': u'grid'},
+                       'ProxyTypes': {u'/etc/gwms-frontend/credentials/hepcloud_fermilab_accesskey': u'key_pair+vm_id',
+                                      u'/etc/gwms-frontend/proxies/cms_proxy': u'grid_proxy+project_id'},
+                       'ProxyUpdateFrequency': {},
+                       'ProxyVMIdFname': {},
+                       'ProxyVMIds': {u'/etc/gwms-frontend/credentials/hepcloud_fermilab_accesskey': u'ami-00000000000'},
+                       'ProxyVMTypeFname': {},
+                       'ProxyVMTypes': {},
+                       'classad_proxy': '/etc/gwms-frontend/proxies/fe_proxy',
+                       'condor_config': '/var/lib/gwms-frontend/vofrontend/frontend.condor_config',
+                       'condor_mapfile': '/var/lib/gwms-frontend/vofrontend/group_cms_all/group.mapfile',
+                       'curb_vms_idle': 4500,
+                       'factory_collectors': [(u'cmssrv200.fnal.gov',
+                                               u'gfactory@cmssrv200.fnal.gov',
+                                               u'hepcloudsvc00@cmssrv200.fnal.gov')],
+                       'fe_total_curb_glideins': 167000,
+                       'fe_total_curb_vms_idle': 25000,
+                       'fe_total_max_glideins': 170000,
+                       'fe_total_max_vms_idle': 35000,
+                       'fraction_running': 3.0,
+                       'global_total_curb_glideins': 167000,
+                       'global_total_curb_vms_idle': 25000,
+                       'global_total_max_glideins': 170000,
+                       'global_total_max_vms_idle': 35000,
+                       'max_idle': 12800,
+                       'max_matchmakers': 3,
+                       'max_running': '40000',
+                       'max_vms_idle': 5000,
+                       'min_running': '0',
+                       'proxies': [u'/etc/gwms-frontend/proxies/cms_proxy',
+                                   u'/etc/gwms-frontend/credentials/hepcloud_fermilab_accesskey'],
+                       'proxy_selection_plugin': 'ProxyAll',
+                       'reserve_idle': 100,
+                       'schedds': ['cmssrv270.fnal.gov',
+                                   'cmssrv277.fnal.gov'],
+                       'security_name': 'hepcloudsvc00',
+                       'sign_descript': {'frontend_descript_fname': 'description.000000.cfg',
+                                         'frontend_descript_signature': '123000000000a000000000a000000000',
+                                         'group_descript_fname': 'description.000000.cfg',
+                                         'group_descript_signature': '321000000000a000000000a000000000',
+                                         'signature_type': 'sha1'},
+                       'total_curb_glideins': 39000,
+                       'total_curb_vms_idle': 39000,
+                       'total_max_glideins': 40000,
+                       'total_max_vms_idle': 40000,
+                       'web_url': 'http://hepcsvc00.fnal.gov:8319/vofrontend/stage/group_cms',
+                       'workdir': '/var/lib/gwms-frontend/vofrontend/group_cms'}}}
+
+
+class TestGlideFrontendElement:
+
+    @staticmethod
+    def read_fe_config(fpath):
+        # to read the configuration in form a fixture file
+        if not os.path.isfile(fpath):
+            raise RuntimeError(
+                'Error reading Frontend config for DE %s. '
+                'Run configure_gwms_frontend.py to generate one and after every change to the frontend configuration.' %
+                fpath)
+        fe_cfg = eval(open(fpath, 'r').read())
+        if not isinstance(fe_cfg, dict):
+            raise ValueError('Frontend config for DE in %s is invalid' %
+                             fpath)
+        return fe_cfg
+
+    def test_compute_glidein_max_running(self):
+        # fe_cfg = self.read_fe_config("de_frontend_config")
+        fe_cfg = FRONTEND_CFG
+        gfe = glide_frontend_element.get_gfe_obj("CMS", "CMS",
+                                                 fe_cfg, "glideinwms")
+        gfe.entry_fraction_glidein_running = 1.15
+        assert gfe.compute_glidein_max_running({'Idle': 412}, 971, 0) == 1591
+        assert gfe.compute_glidein_max_running({'Idle': 100}, 100, 0) == 230
+        assert gfe.compute_glidein_max_running({'Idle': 100}, 0, 0) == 115
+        assert gfe.compute_glidein_max_running({'Idle': 0}, 0, 0) == 0
+        assert gfe.compute_glidein_max_running({'Idle': 0}, 100, 100) == 100
+
+

--- a/tests/glideinwms/test_glide_frontend_element.py
+++ b/tests/glideinwms/test_glide_frontend_element.py
@@ -1,20 +1,44 @@
 import os
 import pytest
 
-# These modules are not used here, adding the import to test for the presence
-# of modules used in glide_frontend_element
+# Test for the presence of modules used in glide_frontend_element
+# Not testing all imports of glide_frontend_element which are
+# from glideinwms.frontend import glideinFrontendConfig
+# from glideinwms.frontend import glideinFrontendInterface
+# from glideinwms.frontend import glideinFrontendPlugins
+# from glideinwms.lib import pubCrypto
+# Using a simple one, assuming that is glideinwms is in the PYTHONPATH,
+# all modules are
+
 gwms_modules_available = True
 try:
-    from glideinwms.frontend import glideinFrontendConfig
-    from glideinwms.frontend import glideinFrontendInterface
-    from glideinwms.frontend import glideinFrontendPlugins
-    from glideinwms.lib import pubCrypto
+    from glideinwms.frontend import checkFrontend
+    with open(checkFrontend.__file__) as fd:
+        line = fd.readline()
 except ImportError:
+    checkFrontend = None
     gwms_modules_available = False
+
+gwms_modules_python3 = False
+if gwms_modules_available:
+    try:
+        with open(checkFrontend.__file__) as fd:
+            line = fd.readline()
+            gwms_modules_python3 = "python3" in line
+    except Exception:
+        # Assuming no Python 3 glideinwms if something goes wrong
+        pass
 
 
 def test_glideinwms_import():
-    assert gwms_modules_available, "glideinwms package is required to test glide_frontend_element"
+    assert gwms_modules_available, "glideinwms package is required"
+
+
+@pytest.mark.skipif(
+    not gwms_modules_available,
+    reason="Python version of glideinwms cannot be tested w/o glideinwms")
+def test_glideinwms_python3():
+    assert gwms_modules_python3, "a Python3 version of glideinwms is required"
 
 
 FRONTEND_CFG = {
@@ -91,8 +115,8 @@ FRONTEND_CFG = {
 
 
 @pytest.mark.skipif(
-    not gwms_modules_available,
-    reason="glide_frontend_element cannot be tested w/o glideinwms")
+    not gwms_modules_available or not gwms_modules_python3,
+    reason="glide_frontend_element cannot be tested w/o Python 3 glideinwms")
 class TestGlideFrontendElement:
     if gwms_modules_available:
         from decisionengine_modules.glideinwms import glide_frontend_element

--- a/tests/glideinwms/test_glide_frontend_element.py
+++ b/tests/glideinwms/test_glide_frontend_element.py
@@ -116,7 +116,7 @@ FRONTEND_CFG = {
     not gwms_modules_available or not gwms_modules_python3,
     reason="glide_frontend_element cannot be tested w/o Python 3 glideinwms")
 class TestGlideFrontendElement:
-    if gwms_modules_available:
+    if gwms_modules_available and gwms_modules_python3:
         from decisionengine_modules.glideinwms import glide_frontend_element
 
     @staticmethod

--- a/tests/glideinwms/test_glide_frontend_element.py
+++ b/tests/glideinwms/test_glide_frontend_element.py
@@ -12,17 +12,15 @@ import pytest
 
 gwms_modules_available = True
 try:
-    from glideinwms.frontend import checkFrontend
-    with open(checkFrontend.__file__) as fd:
-        line = fd.readline()
+    from glideinwms.lib import glideinWMSVersion
 except ImportError:
-    checkFrontend = None
+    glideinWMSVersion = None
     gwms_modules_available = False
 
 gwms_modules_python3 = False
-if gwms_modules_available:
+if gwms_modules_available and glideinWMSVersion is not None:
     try:
-        with open(checkFrontend.__file__) as fd:
+        with open(glideinWMSVersion.__file__) as fd:
             line = fd.readline()
             gwms_modules_python3 = "python3" in line
     except Exception:


### PR DESCRIPTION
Testing GlidinWMS import and compute_glidein_max_running
This requires glideinwms modules to be available (in the PYTHONPATH), otherwise the unit test  will fail.
Furthermore pytest will give warnings (unless `python3 -m pytest -p no:warnings`  is used) because GlideinWMS uses imp which is a deprecated module.