### PR TITLE
Add timeout support for unit test on Jenkins for DE modules repo

### DIFF
--- a/.Jenkinsfile
+++ b/.Jenkinsfile
@@ -122,7 +122,7 @@ pipeline {
                         echo "prepare docker image ${unit_testsStageDockerImage}"
                         sh "docker build -t ${unit_testsStageDockerImage} -f decisionengine_modules/.github/actions/unittest-in-sl7-docker/Dockerfile.jenkins decisionengine_modules/.github/actions/unittest-in-sl7-docker"
                         echo "Run ${STAGE_NAME} tests"
-                        sh "docker run --rm -v ${WORKSPACE}:${WORKSPACE} -w ${WORKSPACE} ${unit_testsStageDockerImage}"
+                        sh "docker run --rm --env PYTEST_TIMEOUT=${PYTEST_TIMEOUT} -v ${WORKSPACE}:${WORKSPACE} -w ${WORKSPACE} ${unit_testsStageDockerImage}"
                     }
                     post {
                         always {

--- a/build/scripts/utils.sh
+++ b/build/scripts/utils.sh
@@ -27,7 +27,7 @@ setup_python_venv() {
 
     source $VENV/bin/activate
 
-    pip_packages="pylint pycodestyle pytest mock tabulate pandas google-api-python-client boto boto3 gcs_oauth2_boto_plugin urllib3 jsonnet"
+    pip_packages="pylint pycodestyle pytest mock tabulate pandas google-api-python-client boto boto3 gcs_oauth2_boto_plugin urllib3 jsonnet pytest-timeout"
     echo "Installing $pip_packages ..."
     pip install --quiet $pip_packages
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
This feature adds timeout support for unit tests on Jenkins.
Among different ways to set the timeout, this implementation uses the environment variable PYTEST_TIMEOUT that can be set as parameter in the Jenkins build and injected as environment variable in the docker container that run unit tests.
The timeout is set in seconds and it is applied to each unit test individually, so in principle it doesn't need to be updated in case new unit test are added.
The default timeout has been set in the Jenkins configuration to 300.

RB: https://fermicloud140.fnal.gov/reviews/r/226/