### PR TITLE
Updating Dockerfile for unittest

### DIFF
--- a/.github/actions/unittest-in-sl7-docker/Dockerfile
+++ b/.github/actions/unittest-in-sl7-docker/Dockerfile
@@ -1,8 +1,4 @@
 FROM hepcloud/decision-engine-ci
-# Adding dependencies for GlideinWMS
-RUN yum install -y python36-m2crypto python-rrdtool osg-wn-client vo-client voms-clients-cpp \
-  python36-ldap3 python36-jwt PyYAML && yum clean all
-# User and test setup
 COPY entrypoint.sh /entrypoint.sh
 RUN groupadd -g 115 decision-engine-ci
 RUN useradd -u 1001 -g 115 decision-engine-ci

--- a/.github/actions/unittest-in-sl7-docker/Dockerfile.jenkins
+++ b/.github/actions/unittest-in-sl7-docker/Dockerfile.jenkins
@@ -1,8 +1,4 @@
 FROM hepcloud/decision-engine-ci
-# Adding dependencies for GlideinWMS
-RUN yum install -y python36-m2crypto python-rrdtool osg-wn-client vo-client voms-clients-cpp \
-  python36-ldap3 python36-jwt PyYAML && yum clean all
-# User and test setup
 COPY entrypoint.sh /entrypoint.sh
 RUN groupadd -g 500 decision-engine-ci
 RUN useradd -u 500 -g 500 decision-engine-ci


### PR DESCRIPTION
These GWMS dependencies have been moved to the base Dockerfile in DE repo.
With this configuration the Docker image is built once and then it is used to run tests.

This update depends on https://github.com/HEPCloud/decisionengine/pull/199

RB: https://fermicloud140.fnal.gov/reviews/r/248/