### PR TITLE
decisionengine_modules/NERSC/util:  Added more 5xx codes to retry

### DIFF
--- a/NERSC/util/newt.py
+++ b/NERSC/util/newt.py
@@ -48,7 +48,7 @@ class Newt(object):
         """
         retry = Retry(
             status=self.num_retries,
-            status_forcelist=[500, ],
+            status_forcelist=[500, 502, 503, 504, 507],
             backoff_factor=self.retry_backoff_factor,
             method_whitelist=False)
         retry_adapter = HTTPAdapter(max_retries=retry)


### PR DESCRIPTION
Added additional 5xx codes for all NERSC API calls to retry upon failure

RB: https://fermicloud140.fnal.gov/reviews/r/261/