### PR TITLE
Add support to use custom docker layer as base of the docker image

### DIFF
--- a/.Jenkinsfile
+++ b/.Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
                             cd ..
                         '''
                         echo "prepare docker image ${pep8StageDockerImage}"
-                        sh "docker build --pull -t ${pep8StageDockerImage} -f decisionengine_modules/.github/actions/pep8-in-sl7-docker/Dockerfile.jenkins decisionengine_modules/.github/actions/pep8-in-sl7-docker/"
+                        sh "docker build --pull --tag ${pep8StageDockerImage} --build-arg BASEIMAGE=hepcloud/decision-engine-ci:${BRANCH} --build-arg USER=\$(id -u) --build-arg GROUP=\$(id -g) -f decisionengine_modules/.github/actions/pep8-in-sl7-docker/Dockerfile.jenkins decisionengine_modules/.github/actions/pep8-in-sl7-docker/"
                         echo "Run ${STAGE_NAME} tests"
                         sh "docker run --rm -v ${WORKSPACE}:${WORKSPACE} -w ${WORKSPACE} ${pep8StageDockerImage}"
                         sh 'for artifact_file in pep8.*.log pylint.*.log results.*.log mail.results; do mv -v ${artifact_file} ${STAGE_NAME}.${artifact_file}; done'
@@ -84,7 +84,7 @@ pipeline {
                             cd ..
                         '''
                         echo "prepare docker image ${pylintStageDockerImage}"
-                        sh "docker build --pull -t ${pylintStageDockerImage} -f decisionengine_modules/.github/actions/pylint-in-sl7-docker/Dockerfile.jenkins decisionengine_modules/.github/actions/pylint-in-sl7-docker/"
+                        sh "docker build --pull --tag ${pylintStageDockerImage} --build-arg BASEIMAGE=hepcloud/decision-engine-ci:${BRANCH} --build-arg USER=\$(id -u) --build-arg GROUP=\$(id -g) -f decisionengine_modules/.github/actions/pylint-in-sl7-docker/Dockerfile.jenkins decisionengine_modules/.github/actions/pylint-in-sl7-docker/"
                         echo "Run ${STAGE_NAME} tests"
                         sh "docker run --rm -v ${WORKSPACE}:${WORKSPACE} -w ${WORKSPACE} ${pylintStageDockerImage}"
                         sh 'for artifact_file in pep8.*.log pylint.*.log results.*.log mail.results; do mv -v ${artifact_file} ${STAGE_NAME}.${artifact_file}; done'
@@ -126,7 +126,7 @@ pipeline {
                             cd ..
                         '''
                         echo "prepare docker image ${unit_testsStageDockerImage}"
-                        sh "docker build --pull -t ${unit_testsStageDockerImage} -f decisionengine_modules/.github/actions/unittest-in-sl7-docker/Dockerfile.jenkins decisionengine_modules/.github/actions/unittest-in-sl7-docker"
+                        sh "docker build --pull --tag ${unit_testsStageDockerImage} --build-arg BASEIMAGE=hepcloud/decision-engine-ci:${BRANCH} --build-arg USER=\$(id -u) --build-arg GROUP=\$(id -g) -f decisionengine_modules/.github/actions/unittest-in-sl7-docker/Dockerfile.jenkins decisionengine_modules/.github/actions/unittest-in-sl7-docker"
                         echo "Run ${STAGE_NAME} tests"
                         sh "docker run --rm --env PYTEST_TIMEOUT=${PYTEST_TIMEOUT} -v ${WORKSPACE}:${WORKSPACE} -w ${WORKSPACE} ${unit_testsStageDockerImage}"
                     }
@@ -167,7 +167,7 @@ pipeline {
                             cd ..
                         '''
                         echo "prepare docker image ${rpmbuildStageDockerImage}"
-                        sh "docker build --pull -t ${rpmbuildStageDockerImage} -f decisionengine_modules/.github/actions/rpmbuild-in-sl7-docker/Dockerfile.jenkins decisionengine_modules/.github/actions/rpmbuild-in-sl7-docker"
+                        sh "docker build --pull --tag ${rpmbuildStageDockerImage} --build-arg BASEIMAGE=hepcloud/decision-engine-ci:${BRANCH} --build-arg USER=\$(id -u) --build-arg GROUP=\$(id -g) -f decisionengine_modules/.github/actions/rpmbuild-in-sl7-docker/Dockerfile.jenkins decisionengine_modules/.github/actions/rpmbuild-in-sl7-docker"
                         echo "Run ${STAGE_NAME} tests"
                         sh "docker run --rm -v ${WORKSPACE}:${WORKSPACE} -w ${WORKSPACE} ${rpmbuildStageDockerImage}"
                     }

--- a/.github/actions/pep8-in-sl7-docker/Dockerfile.jenkins
+++ b/.github/actions/pep8-in-sl7-docker/Dockerfile.jenkins
@@ -1,6 +1,9 @@
-FROM hepcloud/decision-engine-ci
+ARG BASEIMAGE=${BASEIMAGE:-hepcloud/decision-engine-ci}
+FROM ${BASEIMAGE:-hepcloud/decision-engine-ci}
+ARG USER
+ARG GROUP
 COPY entrypoint.sh /entrypoint.sh
-RUN groupadd -g 500 decision-engine-ci
-RUN useradd -u 500 -g 500 decision-engine-ci
+RUN groupadd -g ${GROUP:-500} decision-engine-ci
+RUN useradd -u ${USER:-500} -g ${GROUP:-500} decision-engine-ci
 USER decision-engine-ci
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/pylint-in-sl7-docker/Dockerfile.jenkins
+++ b/.github/actions/pylint-in-sl7-docker/Dockerfile.jenkins
@@ -1,6 +1,9 @@
-FROM hepcloud/decision-engine-ci
+ARG BASEIMAGE=${BASEIMAGE:-hepcloud/decision-engine-ci}
+FROM ${BASEIMAGE:-hepcloud/decision-engine-ci}
+ARG USER
+ARG GROUP
 COPY entrypoint.sh /entrypoint.sh
-RUN groupadd -g 500 decision-engine-ci
-RUN useradd -u 500 -g 500 decision-engine-ci
+RUN groupadd -g ${GROUP:-500} decision-engine-ci
+RUN useradd -u ${USER:-500} -g ${GROUP:-500} decision-engine-ci
 USER decision-engine-ci
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/rpmbuild-in-sl7-docker/Dockerfile.jenkins
+++ b/.github/actions/rpmbuild-in-sl7-docker/Dockerfile.jenkins
@@ -1,6 +1,9 @@
-FROM hepcloud/decision-engine-ci
+ARG BASEIMAGE=${BASEIMAGE:-hepcloud/decision-engine-ci}
+FROM ${BASEIMAGE:-hepcloud/decision-engine-ci}
+ARG USER
+ARG GROUP
 COPY entrypoint.sh /entrypoint.sh
-RUN groupadd -g 500 decision-engine-ci
-RUN useradd -u 500 -g 500 decision-engine-ci
+RUN groupadd -g ${GROUP:-500} decision-engine-ci
+RUN useradd -u ${USER:-500} -g ${GROUP:-500} decision-engine-ci
 USER decision-engine-ci
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/unittest-in-sl7-docker/Dockerfile.jenkins
+++ b/.github/actions/unittest-in-sl7-docker/Dockerfile.jenkins
@@ -1,6 +1,9 @@
-FROM hepcloud/decision-engine-ci
+ARG BASEIMAGE=${BASEIMAGE:-hepcloud/decision-engine-ci}
+FROM ${BASEIMAGE:-hepcloud/decision-engine-ci}
+ARG USER
+ARG GROUP
 COPY entrypoint.sh /entrypoint.sh
-RUN groupadd -g 500 decision-engine-ci
-RUN useradd -u 500 -g 500 decision-engine-ci
+RUN groupadd -g ${GROUP:-500} decision-engine-ci
+RUN useradd -u ${USER:-500} -g ${GROUP:-500} decision-engine-ci
 USER decision-engine-ci
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Add support to use custom docker layer as base of the docker image used to run tests
this allows to use different docker container for different branches.

This code change is also needed for branch 1.4
By looking at the current status of branch 1.4, it also needs commit d2df8610f9c12edf6b142c164a10ba2372bb4848
that corresponds to PR#280 https://github.com/HEPCloud/decisionengine_modules/pull/280
This way the code change in this PR can be applied as is to 1.4 branch.

RB: https://fermicloud140.fnal.gov/reviews/r/286/
