### PR TITLE
Remove cmake step when running unittests 

### DIFF
--- a/.github/actions/unittest-in-sl7-docker/entrypoint.sh
+++ b/.github/actions/unittest-in-sl7-docker/entrypoint.sh
@@ -3,16 +3,8 @@ export PYVER=${1:-"3.6"}
 source decisionengine_modules/build/scripts/utils.sh
 setup_python_venv
 setup_dependencies
-le_builddir=dependencies/decisionengine/framework/logicengine/cxx/build
-[ -e $le_buildir ] && rm -rf $le_builddir
-mkdir $le_builddir
-cd $le_builddir
-cmake3 -Wno-dev  -DPYVER=$PYVER ..
-make
-make liblinks
-cd -
-export PYTHONPATH=$PWD:$PYTHONPATH
 source venv/bin/activate
+export PYTHONPATH=$PWD:$PYTHONPATH
 pytest -v -l --tb=native decisionengine_modules > pytest.log 2>&1
 status=$?
 cat pytest.log

--- a/build/packaging/rpm/decisionengine_modules.spec
+++ b/build/packaging/rpm/decisionengine_modules.spec
@@ -36,15 +36,6 @@ BuildArch:      x86_64
 BuildRequires: python36-devel
 BuildRequires: python3-rpm-macros
 Requires: python3
-#BuildRequires:  cmake numpy numpy-f2py python-pandas
-#BuildRequires:  boost-python boost-regex boost-system
-#Requires:       numpy >= 1.7.1
-#Requires:       numpy-f2py >= 1.7.1
-#Requires:       python-pandas >= 0.17.1
-#Requires:       boost-python >= 1.53.0
-#Requires:       boost-regex >= 1.53.0
-#Requires:       boost-system >= 1.53.0
-
 
 %description
 The Decision Engine is a critical component of the HEPCloud Facility. It


### PR DESCRIPTION
decisionengine framework intriduced pure python implementation
of Logic Engine. Remove building of C++ Logic Engine from unit
tests