### PR TITLE
Fix build of Logic Engine for unittests in branch 1.5

### DIFF
--- a/build/scripts/utils.sh
+++ b/build/scripts/utils.sh
@@ -26,7 +26,7 @@ setup_python_venv() {
     fi
 
     source $VENV/bin/activate
-    pip_packages="pylint pycodestyle pytest mock tabulate pandas google-api-python-client boto boto3 gcs_oauth2_boto_plugin urllib3 jsonnet m2crypto pytest-timeout"
+    pip_packages="pylint pycodestyle pytest mock tabulate pandas google-api-python-client boto boto3 gcs_oauth2_boto_plugin urllib3 jsonnet m2crypto pytest-timeout pybind11-global"
     echo "Installing $pip_packages ..."
     pip install --quiet $pip_packages
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
This change needs to be applied to branch 1.5 of decisionengine_modules.
There is also an associated change in decisionengine repo that is associated to RB#335 (https://fermicloud140.fnal.gov/reviews/r/335/)

RB: https://fermicloud140.fnal.gov/reviews/r/334