### PR TITLE
Fix build/install Logic Engine C++ code for branch 1.5

### DIFF
--- a/.github/actions/unittest-in-sl7-docker/entrypoint.sh
+++ b/.github/actions/unittest-in-sl7-docker/entrypoint.sh
@@ -8,8 +8,7 @@ le_builddir=dependencies/decisionengine/framework/logicengine/cxx/build
 mkdir $le_builddir
 cd $le_builddir
 cmake3 -Wno-dev  -DPYVER=$PYVER ..
-make
-make liblinks
+make install
 cd -
 export PYTHONPATH=$PWD:$PYTHONPATH
 source venv/bin/activate


### PR DESCRIPTION
This PR is for branch 1.5
As suggested by Kyle,
for unittests in branch 1.5 use 'install' target to build/install Logic Engine C++ code instead of 'liblinks' target.
Those targets are doing the same thing.

RB: https://fermicloud140.fnal.gov/reviews/r/352/