### PR TITLE
replaced method_whitelist with allowed_methods (as former os deprecated)

### DIFF
--- a/NERSC/util/newt.py
+++ b/NERSC/util/newt.py
@@ -50,7 +50,7 @@ class Newt(object):
             status=self.num_retries,
             status_forcelist=[500, 502, 503, 504, 507],
             backoff_factor=self.retry_backoff_factor,
-            method_whitelist=False)
+            allowed_methods=False)
         retry_adapter = HTTPAdapter(max_retries=retry)
         self.session.mount(self.newt_base_url, retry_adapter)
 


### PR DESCRIPTION
RB : https://fermicloud140.fnal.gov/reviews/r/368/ 