### PR TITLE
Fix bugs introduced during `@produces`/`@consumes` migration

### DIFF
--- a/AWS/sources/FinancialParameters.py
+++ b/AWS/sources/FinancialParameters.py
@@ -26,7 +26,7 @@ class FinancialParameters(Source.Source):
         Read the financial parameters from the config file and
         return as a dataframe
         """
-        return {'financial_parameters': pandas.DataFrame(self.financial_parameters_dict)}
+        return {'financial_params': pandas.DataFrame(self.financial_parameters_dict)}
 
 
 Source.describe(FinancialParameters,

--- a/GCE/sources/GCEResourceLimits.py
+++ b/GCE/sources/GCEResourceLimits.py
@@ -17,6 +17,8 @@ class GCEResourceLimits(SourceProxy.SourceProxy):
     def __init__(self, config):
         super().__init__(config)
         self.entry_limit_attrs = config.get('entry_limit_attrs')
+        if len(self.data_keys) != 1:
+            raise RuntimeError("Only one element may be specified in the 'Dataproducts' parameter.")
 
     def acquire(self):
         """
@@ -26,8 +28,7 @@ class GCEResourceLimits(SourceProxy.SourceProxy):
         """
 
         factory_data = super().acquire()
-        if len(factory_data) != 1:
-            raise RuntimeError("Incorrect number of elements in data block.")
+        assert len(factory_data) == 1
         df_factory_data = factory_data.popitem()[1]
         df_entry_limits = df_factory_data[self.entry_limit_attrs]
         return {'GCE_Resource_Limits': df_entry_limits}

--- a/GCE/sources/GCEResourceLimits.py
+++ b/GCE/sources/GCEResourceLimits.py
@@ -26,7 +26,9 @@ class GCEResourceLimits(SourceProxy.SourceProxy):
         """
 
         factory_data = super().acquire()
-        df_factory_data = factory_data.get(self.data_keys[0])
+        if len(factory_data) != 1:
+            raise RuntimeError("Incorrect number of elements in data block.")
+        df_factory_data = factory_data.popitem()[1]
         df_entry_limits = df_factory_data[self.entry_limit_attrs]
         return {'GCE_Resource_Limits': df_entry_limits}
 

--- a/glideinwms/transforms/glidein_requests.py
+++ b/glideinwms/transforms/glidein_requests.py
@@ -86,10 +86,10 @@ class GlideinRequestManifests(Transform.Transform):
             # TODO: This will be influenced once we can configure different
             #       resource selection plugins. Currently supports FOM only.
             foms = {
-                'Grid_Figure_Of_Merit': self.Grid_Figure_Of_Merit(),
-                'GCE_Figure_Of_Merit': self.GCE_Figure_Of_Merit(),
-                'AWS_Figure_Of_Merit': self.AWS_Figure_Of_Merit(),
-                'Nersc_Figure_Of_Merit': self.Nersc_Figure_Of_Merit()
+                'Grid_Figure_Of_Merit': self.Grid_Figure_Of_Merit(datablock),
+                'GCE_Figure_Of_Merit': self.GCE_Figure_Of_Merit(datablock),
+                'AWS_Figure_Of_Merit': self.AWS_Figure_Of_Merit(datablock),
+                'Nersc_Figure_Of_Merit': self.Nersc_Figure_Of_Merit(datablock)
             }
             fom_entries = fom_eligible_resources(foms,
                                                  constraint=self.fom_resource_constraint,
@@ -98,11 +98,11 @@ class GlideinRequestManifests(Transform.Transform):
             self.logger.debug(fom_entries)
 
             # Get the jobs dataframe
-            jobs_df = self.job_manifests()
+            jobs_df = self.job_manifests(datablock)
             # Get the job clusters dataframe
-            job_clusters_df = self.job_clusters()
+            job_clusters_df = self.job_clusters(datablock)
             # Get HTCondor slots dataframe
-            slots_df = self.startd_manifests()
+            slots_df = self.startd_manifests(datablock)
 
             # self.logger.info(job_clusters_df)
             for index, row in job_clusters_df.iterrows():

--- a/tests/test_GCEResourceLimits.py
+++ b/tests/test_GCEResourceLimits.py
@@ -2,6 +2,7 @@ import os
 
 import mock
 import pandas
+import pytest
 import typing
 
 import decisionengine.framework.config.ChannelConfigHandler as configmanager
@@ -32,7 +33,6 @@ CONFIG = {
 
 _PRODUCES = {"GCE_Resource_Limits": typing.Any}
 
-
 def test_produces():
     with mock.patch.object(configmanager, "ChannelConfigHandler"), \
          mock.patch.object(dataspace, "DataSpace"):
@@ -49,3 +49,8 @@ def test_acquire():
         gce_limits = gce_resource_limits.acquire()
         assert _PRODUCES.keys() == gce_limits.keys()
         assert CONFIG.get("entry_limit_attrs").sort() == list(gce_limits.get('GCE_Resource_Limits')).sort()
+
+def test_config():
+    CONFIG['Dataproducts'].insert(0, "bad")
+    with pytest.raises(RuntimeError, match="Only one element may be specified"):
+        GCEResourceLimits.GCEResourceLimits(CONFIG)


### PR DESCRIPTION
This PR handles a breaking change introduced by PR HEPCloud/decisionengine#386.  The unit tests will not pass until that PR has been merged into the framework's master branch.