### PR TITLE
Adding new test for correction map

### DIFF
--- a/src/decisionengine_modules/tests/test_factory_entries.py
+++ b/src/decisionengine_modules/tests/test_factory_entries.py
@@ -50,10 +50,10 @@ CONFIG_FACTORY_ENTRIES_CORMAP = {
             "collector_host": "dummy_collector.fnal.gov",
             "classad_attrs": ['GLIDEIN_GridType', "GLIDEIN_CMSSite", 'GLIDEIN_Resource_Slots'],
             "correction_map": {
-                "GLIDEIN_Resource_Slots":'DummySlots',
-                "GLIDEIN_CMSSite":'DummySite'
+                "GLIDEIN_Resource_Slots": 'DummySlots',
+                "GLIDEIN_CMSSite": 'DummySite'
             }
-            },
+        },
     ]
 }
 
@@ -94,8 +94,8 @@ class TestFactoryEntries:
             assert(df.dropna().empty is True)
 
     def test_acquire_correctionmap(self):
-        d1 = {'GLIDEIN_Resource_Slots': ['DummySlots', 'DummySlots'] }
-        d2 = {'GLIDEIN_CMSSite': ['DummySite', 'DummySite'] }
+        d1 = {'GLIDEIN_Resource_Slots': ['DummySlots', 'DummySlots']}
+        d2 = {'GLIDEIN_CMSSite': ['DummySite', 'DummySite']}
         df1 = pd.DataFrame(data=d1)
         df2 = pd.DataFrame(data=d2)
 
@@ -104,5 +104,5 @@ class TestFactoryEntries:
             f.return_value = utils.input_from_file(FIXTURE_FILE)
             dummypd = entries.acquire()
             dummypd2 = dummypd['Factory_Entries_Grid']
-            assert( df1.equals( dummypd2[['GLIDEIN_Resource_Slots']]) )
-            assert( df2.equals( dummypd2[['GLIDEIN_CMSSite']]) )
+            assert(df1.equals(dummypd2[['GLIDEIN_Resource_Slots']]))
+            assert(df2.equals(dummypd2[['GLIDEIN_CMSSite']]))


### PR DESCRIPTION
I added one more method to test_factory_entries.py to test 
the correction map logic in glideinwms/source/factory_entries.py