### PR TITLE
Legacy boto isn't used internally any longer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,12 @@ long_description = (here / "README.md").read_text(encoding="utf-8")
 
 # pull in runtime requirements
 runtime_require = [
-    "boto >= 2.49.0", "boto3 >= 1.17.10", "google_auth >= 1.16.0, < 2dev",
-    "google-api-python-client >= 1.12.8", "gcs-oauth2-boto-plugin >= 2.7",
-    "htcondor >= 8.9.11", "urllib3 >= 1.25.6",
+    "boto3 >= 1.17.10",
+    "google_auth >= 1.16.0, < 2dev",
+    "google-api-python-client >= 1.12.8",
+    "gcs-oauth2-boto-plugin >= 2.7",
+    "htcondor >= 8.9.11",
+    "urllib3 >= 1.25.6",
     "bill-calculator-hep >= 0.1.2",
     "numpy == 1.19.5; python_version <= '3.6'",
     "numpy >= 1.19.5; python_version >= '3.7'",

--- a/src/decisionengine_modules/tests/test_GCEBillingInfo.py
+++ b/src/decisionengine_modules/tests/test_GCEBillingInfo.py
@@ -19,7 +19,7 @@ config_billing_info = {'projectId': 'hepcloud-fnal',
                        'accountNumber': 1111,
                        'credentialsProfileName': 'BillingBlah',
                        'applyDiscount': True,  # DLT discount does not apply to credits
-                       'botoConfig': ".boto",
+                       'botoConfig': ".boto3",
                        'localFileDir': "."}
 
 class TestGCEBillingInfo:


### PR DESCRIPTION
As we look at what it will take to get packaging in place, we can drop legacy `boto` as we've moved to `boto3` everywhere.

The `botoConfig` param isn't currently used.

One of our dependent modules uses `boto`, but it has the correct requirements to pull in what it needs.