### PR TITLE
Allow use of custom DEframework branch to test DE modules

### DIFF
--- a/.Jenkins/workflows/Jenkinsfile
+++ b/.Jenkins/workflows/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
                         echo "prepare docker image ${flake8StageDockerImage}"
                         sh "docker build --pull --tag ${flake8StageDockerImage} --build-arg BASEIMAGE=hepcloud/decision-engine-ci:${BRANCH} --build-arg UID=\$(id -u) --build-arg GID=\$(id -g) -f decisionengine_modules/package/ci/Dockerfile decisionengine_modules/package/ci/"
                         echo "Run ${STAGE_NAME} tests"
-                        sh "docker run --rm --env PYTEST_TIMEOUT=${PYTEST_TIMEOUT} -v ${WORKSPACE}/decisionengine_modules:${WORKSPACE}/decisionengine_modules -w ${WORKSPACE}/decisionengine_modules ${flake8StageDockerImage} \"-m pytest -m flake8 --flake8\" \"flake8.log\""
+                        sh "docker run --rm --env GITHUB_PR_NUMBER=${GITHUB_PR_NUMBER} --env PYTEST_TIMEOUT=${PYTEST_TIMEOUT} -v ${WORKSPACE}/decisionengine_modules:${WORKSPACE}/decisionengine_modules -w ${WORKSPACE}/decisionengine_modules ${flake8StageDockerImage} \"-m pytest -m flake8 --flake8\" \"flake8.log\" \"${BRANCH}\""
                     }
                     post {
                         always {
@@ -91,7 +91,7 @@ pipeline {
                         echo "prepare docker image ${unit_testsStageDockerImage}"
                         sh "docker build --pull --tag ${unit_testsStageDockerImage} --build-arg BASEIMAGE=hepcloud/decision-engine-ci:${BRANCH} --build-arg UID=\$(id -u) --build-arg GID=\$(id -g) -f decisionengine_modules/package/ci/Dockerfile decisionengine_modules/package/ci/"
                         echo "Run ${STAGE_NAME} tests"
-                        sh "docker run --rm --env PYTEST_TIMEOUT=${PYTEST_TIMEOUT} -v ${WORKSPACE}/decisionengine_modules:${WORKSPACE}/decisionengine_modules -w ${WORKSPACE}/decisionengine_modules ${unit_testsStageDockerImage} \"-m pytest --cov-report term --cov=decisionengine_modules --no-cov-on-fail\" \"pytest.log\""
+                        sh "docker run --rm --env GITHUB_PR_NUMBER=${GITHUB_PR_NUMBER} --env PYTEST_TIMEOUT=${PYTEST_TIMEOUT} -v ${WORKSPACE}/decisionengine_modules:${WORKSPACE}/decisionengine_modules -w ${WORKSPACE}/decisionengine_modules ${unit_testsStageDockerImage} \"-m pytest --cov-report term --cov=decisionengine_modules --no-cov-on-fail\" \"pytest.log\" \"${BRANCH}\""
                     }
                     post {
                         always {
@@ -135,7 +135,7 @@ pipeline {
                         echo "prepare docker image ${rpmbuildStageDockerImage}"
                         sh "docker build --pull --tag ${rpmbuildStageDockerImage} --build-arg BASEIMAGE=hepcloud/decision-engine-ci:${BRANCH} --build-arg UID=\$(id -u) --build-arg GID=\$(id -g) -f decisionengine_modules/package/ci/Dockerfile decisionengine_modules/package/ci/"
                         echo "Run ${STAGE_NAME} tests"
-                        sh "docker run --rm --env PYTEST_TIMEOUT=${PYTEST_TIMEOUT} -v ${WORKSPACE}/decisionengine_modules:${WORKSPACE}/decisionengine_modules -w ${WORKSPACE}/decisionengine_modules ${rpmbuildStageDockerImage} \"setup.py bdist_rpm\" \"rpmbuild.log\""
+                        sh "docker run --rm --env GITHUB_PR_NUMBER=${GITHUB_PR_NUMBER} --env PYTEST_TIMEOUT=${PYTEST_TIMEOUT} -v ${WORKSPACE}/decisionengine_modules:${WORKSPACE}/decisionengine_modules -w ${WORKSPACE}/decisionengine_modules ${rpmbuildStageDockerImage} \"setup.py bdist_rpm\" \"rpmbuild.log\" \"${BRANCH}\""
                     }
                     post {
                         always {

--- a/package/ci/python3-entrypoint.sh
+++ b/package/ci/python3-entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/bash -xe
 CMD=${1:- -m pytest}
 LOGFILE=${2:- pytest.log}
+# set defaul DE_BRANCH to master or eventually set it as entrypoint script argument
+DE_BRANCH=${3:-master}
+
+# check DE modules branch
+# the entrypoint script is supposed to run inside DE modules folder
+# GITHUB_PR_NUMBER is set in Jenkins for PR
+# CI on GitHub for PR uses a HEAD detached branch
+# if we have a different case, we are testing an actual branch
+[[ -z ${GITHUB_PR_NUMBER} && $(git rev-parse --abbrev-ref HEAD) != "HEAD" ]] && DE_BRANCH=$(git rev-parse --abbrev-ref HEAD) || :
+echo "DE_BRANCH: ${DE_BRANCH}"
 
 id
 getent passwd $(whoami)
@@ -9,7 +19,7 @@ echo ''
 
 # checkout DE Framework
 rm -rf decisionengine
-git clone https://github.com/HEPCloud/decisionengine.git
+git clone -b ${DE_BRANCH} https://github.com/HEPCloud/decisionengine.git
 
 # checkout GlideinWMS for python3
 rm -rf glideinwms


### PR DESCRIPTION
This PR allows to use a custom branch of DE framework to test DE modules.
Default branch is set to be "master".
This solves issue #333 for master branch.
