### PR TITLE
Allow use of custom DEframework branch to test DE modules for branch 1.6

### DIFF
--- a/.Jenkins/workflows/Jenkinsfile
+++ b/.Jenkins/workflows/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
                         echo "prepare docker image ${flake8StageDockerImage}"
                         sh "docker build --pull --tag ${flake8StageDockerImage} --build-arg BASEIMAGE=hepcloud/decision-engine-ci:${BRANCH} --build-arg UID=\$(id -u) --build-arg GID=\$(id -g) -f decisionengine_modules/package/ci/Dockerfile decisionengine_modules/package/ci/"
                         echo "Run ${STAGE_NAME} tests"
-                        sh "docker run --rm --env PYTEST_TIMEOUT=${PYTEST_TIMEOUT} -v ${WORKSPACE}:${WORKSPACE} -w ${WORKSPACE} ${flake8StageDockerImage} \"-m pytest -m flake8 --flake8 decisionengine_modules\" \"flake8.log\""
+                        sh "docker run --rm --env PYTEST_TIMEOUT=${PYTEST_TIMEOUT} -v ${WORKSPACE}:${WORKSPACE} -w ${WORKSPACE} ${flake8StageDockerImage} \"-m pytest -m flake8 --flake8 decisionengine_modules\" \"flake8.log\" \"${BRANCH}\""
                     }
                     post {
                         always {
@@ -91,7 +91,7 @@ pipeline {
                         echo "prepare docker image ${unit_testsStageDockerImage}"
                         sh "docker build --pull --tag ${unit_testsStageDockerImage} --build-arg BASEIMAGE=hepcloud/decision-engine-ci:${BRANCH} --build-arg UID=\$(id -u) --build-arg GID=\$(id -g) -f decisionengine_modules/package/ci/Dockerfile decisionengine_modules/package/ci/"
                         echo "Run ${STAGE_NAME} tests"
-                        sh "docker run --rm --env PYTEST_TIMEOUT=${PYTEST_TIMEOUT} -v ${WORKSPACE}:${WORKSPACE} -w ${WORKSPACE} ${unit_testsStageDockerImage} \"-m pytest --cov-report term --cov=decisionengine_modules --no-cov-on-fail decisionengine_modules\" \"pytest.log\""
+                        sh "docker run --rm --env PYTEST_TIMEOUT=${PYTEST_TIMEOUT} -v ${WORKSPACE}:${WORKSPACE} -w ${WORKSPACE} ${unit_testsStageDockerImage} \"-m pytest --cov-report term --cov=decisionengine_modules --no-cov-on-fail decisionengine_modules\" \"pytest.log\" \"${BRANCH}\""
                     }
                     post {
                         always {

--- a/package/ci/python3-entrypoint.sh
+++ b/package/ci/python3-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -xe
 CMD=${1:- -m pytest}
 LOGFILE=${2:- pytest.log}
-DE_BRANCH=${3:-master}
+DE_BRANCH=${3:-1.6}
 
 id
 getent passwd $(whoami)

--- a/package/ci/python3-entrypoint.sh
+++ b/package/ci/python3-entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -xe
 CMD=${1:- -m pytest}
 LOGFILE=${2:- pytest.log}
+DE_BRANCH=${3:-master}
 
 id
 getent passwd $(whoami)
@@ -9,7 +10,7 @@ echo ''
 
 # checkout DE Framework
 rm -rf decisionengine
-git clone https://github.com/HEPCloud/decisionengine.git
+git clone -b ${DE_BRANCH} https://github.com/HEPCloud/decisionengine.git
 
 # checkout GlideinWMS for python3
 rm -rf glideinwms


### PR DESCRIPTION
This PR is for branch 1.6. This allows to use a custom branch of DE framework to test DE modules.
Default branch is set to be "master", but on Jenkins the pipeline configuration provides the proper branch. 
This solves issue #333 for 1.6 branch.