### PR TITLE
Don't package tests at top level

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     license=about.__license__,
     package_dir={"": "src"},
     packages=find_packages(where="src",
-                           exclude=("*.tests", "*.tests.*", "build.*",
+                           exclude=("tests", "*.tests", "*.tests.*", "build.*",
                                     "doc.*")),
     install_requires=runtime_require,
     extras_require={


### PR DESCRIPTION
This should clean up the unneeded package of toplevel tests.