### PR TITLE
Rename bill_calculator_hep imports

### DIFF
--- a/src/decisionengine_modules/AWS/sources/BillingInfo.py
+++ b/src/decisionengine_modules/AWS/sources/BillingInfo.py
@@ -6,7 +6,7 @@ import pandas as pd
 from decisionengine.framework.modules import Source
 from decisionengine.framework.modules.Source import Parameter
 from decisionengine_modules.AWS.sources import DEAccountContants
-from billing_calculator_hep.AWSBillAnalysis import AWSBillCalculator
+from bill_calculator_hep.AWSBillAnalysis import AWSBillCalculator
 
 
 @Source.supports_config(Parameter('billing_configuration',

--- a/src/decisionengine_modules/GCE/sources/GCEBillingInfo.py
+++ b/src/decisionengine_modules/GCE/sources/GCEBillingInfo.py
@@ -3,7 +3,7 @@ import pandas as pd
 
 from decisionengine.framework.modules import Source
 from decisionengine.framework.modules.Source import Parameter
-from billing_calculator_hep.GCEBillAnalysis import GCEBillCalculator
+from bill_calculator_hep.GCEBillAnalysis import GCEBillCalculator
 
 
 @Source.supports_config(Parameter('projectId', type=str),

--- a/src/decisionengine_modules/tests/test_GCEBillingInfo.py
+++ b/src/decisionengine_modules/tests/test_GCEBillingInfo.py
@@ -1,5 +1,5 @@
 from decisionengine_modules.GCE.sources import GCEBillingInfo
-from billing_calculator_hep.GCEBillAnalysis import GCEBillCalculator
+from bill_calculator_hep.GCEBillAnalysis import GCEBillCalculator
 
 import structlog
 import pandas


### PR DESCRIPTION
The `billing_calculator_hep` package was renamed to `bill_calculator_hep`. This PR renames its imports accordingly.