### PR TITLE
changes needed for structured logging

### DIFF
--- a/src/decisionengine_modules/AWS/publishers/AWS_figure_of_merit.py
+++ b/src/decisionengine_modules/AWS/publishers/AWS_figure_of_merit.py
@@ -10,8 +10,10 @@ from decisionengine_modules.AWS.publishers.AWS_generic_publisher import AWSGener
 class AWSFOMPublisher(publisher):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
 
     def graphite_context(self, dataframe):
+        self.logger.debug("in AWSFOMPublisher graphite_context")
         d = {}
         for i, row in dataframe.iterrows():
             key = ('%s.%s.FOM' % (row['AccountName'], row['EntryName']))

--- a/src/decisionengine_modules/AWS/publishers/AWS_generic_publisher.py
+++ b/src/decisionengine_modules/AWS/publishers/AWS_generic_publisher.py
@@ -16,6 +16,8 @@ DEFAULT_GRAPHITE_CONTEXT = ""
 class AWSGenericPublisher(Publisher.Publisher, metaclass=abc.ABCMeta):
 
     def __init__(self, config):
+        super().__init__(config)
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
         self.graphite_host = config.get(
             'graphite_host', DEFAULT_GRAPHITE_HOST)
         self.graphite_port = config.get(
@@ -45,6 +47,7 @@ class AWSGenericPublisher(Publisher.Publisher, metaclass=abc.ABCMeta):
         :arg data_block: data block
 
         """
+        self.logger.debug("in AWSGenericPublisher publish")
         if not self._consumes:
             return
         data = data_block[list(self._consumes.keys())[0]]

--- a/src/decisionengine_modules/AWS/publishers/AWS_price_performance.py
+++ b/src/decisionengine_modules/AWS/publishers/AWS_price_performance.py
@@ -11,8 +11,10 @@ import decisionengine_modules.graphite_client as graphite
 class AWSPricePerformancePublisher(publisher):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
 
     def graphite_context(self, dataframe):
+        self.logger.debug("in AWSPricePerformancePublisher graphite_context")
         d = {}
         for i, row in dataframe.iterrows():
             key = ('%s.%s.%s.price_perf' % (

--- a/src/decisionengine_modules/AWS/sources/AWSInstancePerformance.py
+++ b/src/decisionengine_modules/AWS/sources/AWSInstancePerformance.py
@@ -6,14 +6,16 @@ import pandas as pd
 from decisionengine.framework.modules import Source
 from decisionengine.framework.modules.Source import Parameter
 
-
 @Source.supports_config(Parameter('data_file', type=str, comment="CSV cost data file"))
 @Source.produces(Performance_Data=pd.DataFrame)
 class AWSInstancePerformance(Source.Source):
     def __init__(self, config):
+        super().__init__(config)
         self.data_file = config.get('data_file')
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
 
     def acquire(self):
+        self.logger.debug("in AWSInstancePerformance acquire")
         dataframe = pd.read_csv(self.data_file).drop_duplicates(subset=['AvailabilityZone',
                                                                         'InstanceType'],
                                                                 keep='last').reset_index(drop=True)

--- a/src/decisionengine_modules/AWS/sources/AWSJobLimits.py
+++ b/src/decisionengine_modules/AWS/sources/AWSJobLimits.py
@@ -16,9 +16,12 @@ _TO = 20
 @Source.produces(Job_Limits=pd.DataFrame)
 class AWSJobLimits(Source.Source):
     def __init__(self, config):
+        super().__init__(config)
         self.data_file = config['data_file']
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
 
     def acquire(self):
+        self.logger.debug("in AWSJobLimits acquire")
         rc = None
         for i in range(_RETRIES):
             if os.path.exists(self.data_file):

--- a/src/decisionengine_modules/AWS/sources/AWSOccupancy.py
+++ b/src/decisionengine_modules/AWS/sources/AWSOccupancy.py
@@ -7,7 +7,6 @@ import pandas as pd
 from decisionengine.framework.modules import Source
 from decisionengine.framework.modules.Source import Parameter
 
-import structlog
 import decisionengine_modules.load_config as load_config
 
 # default values
@@ -141,8 +140,10 @@ and the entries in the lists (e.g. "RegionName1") are the name of a region (eg. 
 @Source.produces(AWS_Occupancy=pd.DataFrame)
 class AWSOccupancy(Source.Source):
     def __init__(self, configdict):
+        super().__init__(configdict)
         self.config_file = configdict['occupancy_configuration']
-        self.logger = structlog.getLogger()
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
+
 
     def acquire(self):
         """

--- a/src/decisionengine_modules/AWS/sources/AWSOccupancyWithSourceProxy.py
+++ b/src/decisionengine_modules/AWS/sources/AWSOccupancyWithSourceProxy.py
@@ -5,7 +5,6 @@ import boto3
 import pandas as pd
 
 from decisionengine.framework.modules import Source, SourceProxy
-import structlog
 
 
 class OccupancyData:
@@ -123,7 +122,7 @@ class OccupancyForRegion:
 class AWSOccupancy(SourceProxy.SourceProxy):
     def __init__(self, config):
         super().__init__(config)
-        self.logger = structlog.getLogger()
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
 
     def acquire(self):
         """
@@ -159,7 +158,8 @@ class AWSOccupancy(SourceProxy.SourceProxy):
 
 
 Source.describe(AWSOccupancy,
-                sample_config={"channel_name": "channel_aws_config_data",
+                sample_config={"channel_name": "test",
+                               "source_channel": "channel_aws_config_data",
                                "Dataproducts": ["spot_occupancy_config"],
                                "retries": 3,
                                "retry_timeout": 20})

--- a/src/decisionengine_modules/AWS/sources/AWSSpotPrice.py
+++ b/src/decisionengine_modules/AWS/sources/AWSSpotPrice.py
@@ -11,9 +11,10 @@ import boto3
 from decisionengine.framework.modules import Source
 from decisionengine.framework.modules.Source import Parameter
 import decisionengine_modules.load_config as load_config
+from decisionengine.framework.modules.logging_configDict import CHANNELLOGGERNAME
 
-logger = structlog.getLogger()
-logger = logger.bind(module=__name__.split(".")[-1])
+logger = structlog.getLogger(CHANNELLOGGERNAME)
+logger = logger.bind(module=__name__.split(".")[-1], channel="")
 
 # default values
 REGION = 'us-west-2'
@@ -185,7 +186,9 @@ all instances is acquired.'''))
 @Source.produces(provisioner_resource_spot_prices=pd.DataFrame)
 class AWSSpotPrice(Source.Source):
     def __init__(self, config_dict):
+        super().__init__(config)
         self.config_file = config_dict['spot_price_configuration']
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
 
     def acquire(self):
         """
@@ -196,6 +199,7 @@ class AWSSpotPrice(Source.Source):
 
         # Load kown accounts configuration
         # account configuration is dynamic
+        self.logger.debug("in AWSSpotPrice acquire")
         account_dict = load_config.load(self.config_file, 5, 20)
         sp_data = []
         for account in account_dict:

--- a/src/decisionengine_modules/AWS/sources/AWSSpotPriceWithSourceProxy.py
+++ b/src/decisionengine_modules/AWS/sources/AWSSpotPriceWithSourceProxy.py
@@ -9,9 +9,10 @@ import pandas as pd
 import boto3
 
 from decisionengine.framework.modules import Source, SourceProxy
+from decisionengine.framework.modules.logging_configDict import CHANNELLOGGERNAME
 
-logger = structlog.getLogger()
-logger = logger.bind(module=__name__.split(".")[-1])
+logger = structlog.getLogger(CHANNELLOGGERNAME)
+logger = logger.bind(module=__name__.split(".")[-1], channel="")
 
 # default values
 REGION = 'us-west-2'
@@ -168,6 +169,7 @@ class AWSSpotPriceForRegion:
 class AWSSpotPrice(SourceProxy.SourceProxy):
     def __init__(self, config):
         super().__init__(config)
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
 
     def acquire(self):
         """
@@ -177,6 +179,7 @@ class AWSSpotPrice(SourceProxy.SourceProxy):
         """
 
         # Load known accounts configuration
+        self.logger.debug("in AWSSpotPrice-SP acquire")
         account_conf = super().acquire()
         if len(account_conf.keys()) != 1:
             raise RuntimeError(
@@ -202,7 +205,7 @@ class AWSSpotPrice(SourceProxy.SourceProxy):
 
 
 Source.describe(AWSSpotPrice,
-                sample_config={"channel_name": "channel_aws_config_data",
+                sample_config={"source_channel": "channel_aws_config_data",
                                "Dataproducts": ["spot_occupancy_config"],
                                "retries": 3,
                                "retry_timeout": 20})

--- a/src/decisionengine_modules/AWS/sources/BillingInfo.py
+++ b/src/decisionengine_modules/AWS/sources/BillingInfo.py
@@ -1,5 +1,4 @@
 import datetime
-import structlog
 import time
 import pandas as pd
 
@@ -32,8 +31,9 @@ from bill_calculator_hep.AWSBillAnalysis import AWSBillCalculator
                  AWS_Billing_Rate=pd.DataFrame)
 class BillingInfo(Source.Source):
     def __init__(self, config):
+        super().__init__(config)
         acconts_config_file = config['billing_configuration']
-        self.logger = structlog.getLogger()
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
         self.billing_files_location = config['dst_dir_for_s3_files']
         self.verbose_flag = int(config['verbose_flag'])
         # Load kown accounts configuration
@@ -52,6 +52,7 @@ class BillingInfo(Source.Source):
         """
 
         # get data for all accounts
+        self.logger.debug("in BillingInfo acquire")
         data = []
         datarate = []
         globalConf = {'graphite_host': 'dummy', 'graphite_context_billing': 'dummy', 'outputPath': self.billing_files_location, 'accountDirs': 1}

--- a/src/decisionengine_modules/AWS/sources/FinancialParameters.py
+++ b/src/decisionengine_modules/AWS/sources/FinancialParameters.py
@@ -19,6 +19,7 @@ class FinancialParameters(Source.Source):
     def __init__(self, config):
         super().__init__(config)
         self.financial_parameters_dict = config.get('financial_parameters')
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
 
     # The DataBlock given to the source is t=0
     def acquire(self):
@@ -26,6 +27,7 @@ class FinancialParameters(Source.Source):
         Read the financial parameters from the config file and
         return as a dataframe
         """
+        self.logger.debug("in FinancialParameters acquire")
         return {'financial_params': pandas.DataFrame(self.financial_parameters_dict)}
 
 

--- a/src/decisionengine_modules/AWS/sources/LocalCapacity.py
+++ b/src/decisionengine_modules/AWS/sources/LocalCapacity.py
@@ -1,12 +1,13 @@
 from decisionengine.framework.modules import Source
 
-
 @Source.produces(local_slots=int)
 class LocalCapacity(Source.Source):
 
     def __init__(self, params_dict):
-        pass
+        super().__init__(config)
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
 
     # The DataBlock given to the source is t=0
     def acquire(self):
+        self.logger.debug("in LocalCapacity acquire")
         return {"local_slots": 1}

--- a/src/decisionengine_modules/AWS/tests/test_AWSInstancePerformance.py
+++ b/src/decisionengine_modules/AWS/tests/test_AWSInstancePerformance.py
@@ -7,8 +7,8 @@ import decisionengine_modules.AWS.sources.AWSInstancePerformance as AWSInstanceP
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 
-config = {'data_file': os.path.join(DATA_DIR,
-                                    'instance_performance_sample.csv')}
+config = {'channel_name': "test",
+          'data_file': os.path.join(DATA_DIR, 'instance_performance_sample.csv')}
 
 expected_pandas_df = pd.read_csv(config.get("data_file")).drop_duplicates(subset=['AvailabilityZone', 'InstanceType'],
                                                                           keep='last').reset_index(drop=True)

--- a/src/decisionengine_modules/AWS/tests/test_AWSJobLimits.py
+++ b/src/decisionengine_modules/AWS/tests/test_AWSJobLimits.py
@@ -7,8 +7,8 @@ import decisionengine_modules.AWS.sources.AWSJobLimits as AWSJobLimits
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 
-config = {'data_file': os.path.join(DATA_DIR,
-                                    'job_limits_sample.csv')}
+config = {'channel_name': "test",
+          'data_file': os.path.join(DATA_DIR, 'job_limits_sample.csv')}
 
 expected_pandas_df = pd.read_csv(config.get("data_file")).drop_duplicates(subset=['AvailabilityZone', 'InstanceType'],
                                                                           keep='last').reset_index(drop=True)

--- a/src/decisionengine_modules/AWS/tests/test_AWSOccupancyWithSourceProxy.py
+++ b/src/decisionengine_modules/AWS/tests/test_AWSOccupancyWithSourceProxy.py
@@ -11,7 +11,8 @@ from decisionengine_modules.util import testutils as utils
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 
-config = {"channel_name": "channel_aws_config_data",
+config = {"channel_name": "test",
+          "source_channel": "channel_aws_config_data",
           "Dataproducts": ["spot_occupancy_config"],
           "retries": 3,
           "retry_timeout": 20,

--- a/src/decisionengine_modules/AWS/tests/test_AWSSpotPriceWithSourceProxy.py
+++ b/src/decisionengine_modules/AWS/tests/test_AWSSpotPriceWithSourceProxy.py
@@ -12,7 +12,7 @@ from decisionengine_modules.util import testutils as utils
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 
-config = {"channel_name": "channel_aws_config_data",
+config = {"source_channel": "channel_aws_config_data",
           "Dataproducts": ["spot_occupancy_config"],
           "retries": 3,
           "retry_timeout": 20,

--- a/src/decisionengine_modules/AWS/tests/test_AWS_figure_of_merit_publisher.py
+++ b/src/decisionengine_modules/AWS/tests/test_AWS_figure_of_merit_publisher.py
@@ -19,7 +19,7 @@ OUTPUT_FILE = "AWS_figure_of_merit_pub.csv"
 
 
 def create_datablock():
-    data_block = {}
+    data_block = {'channel_name': "test"}
     try:
         # pandas 1.2 uses a new method for floats, use the "legacy" one for now
         # https://pandas.pydata.org/pandas-docs/stable/whatsnew/v1.2.0.html#change-in-default-floating-precision-for-read-csv-and-read-table
@@ -39,7 +39,8 @@ class TestAWSFOMPublisher(unittest.TestCase):
                                                           'graphite_host': 'fifemondata.fnal.gov',
                                                           'graphite_port': 2104,
                                                           'graphite_context': 'hepcloud.aws',
-                                                          'output_file': OUTPUT_FILE})
+                                                          'output_file': OUTPUT_FILE,
+                                                          'channel_name': "test"})
 
     def tearDown(self):
         try:

--- a/src/decisionengine_modules/AWS/tests/test_AWS_price_performance_publisher.py
+++ b/src/decisionengine_modules/AWS/tests/test_AWS_price_performance_publisher.py
@@ -13,7 +13,7 @@ EXPECTED_REPLY = pd.read_csv(os.path.join(DATA_DIR,
 
 
 def create_datablock():
-    data_block = {}
+    data_block = {'channel_name': "test"}
     data_block['AWS_Price_Performance'] = pd.read_csv(
         os.path.join(DATA_DIR, 'expected_price_performance.csv'))
     return data_block
@@ -26,7 +26,8 @@ class TestAWSPPPublisher(unittest.TestCase):
                                                                      'graphite_host': 'fifemondata.fnal.gov',
                                                                      'graphite_port': 2104,
                                                                      'graphite_context': 'hepcloud.aws',
-                                                                     'output_file': OUTPUT_FILE})
+                                                                     'output_file': OUTPUT_FILE,
+                                                                     'channel_name': "test"})
 
     def tearDown(self):
         try:

--- a/src/decisionengine_modules/AWS/tests/test_FigureOfMerit.py
+++ b/src/decisionengine_modules/AWS/tests/test_FigureOfMerit.py
@@ -21,7 +21,7 @@ produces = dict.fromkeys(['AWS_Price_Performance', 'AWS_Figure_Of_Merit'], pd.Da
 
 
 def create_datablock():
-    data_block = {}
+    data_block = {'channel_name': "test"}
     data_block['provisioner_resource_spot_prices'] = pd.read_csv(os.path.join(
         DATA_DIR, 'AWSSpotPriceWithSourceProxy_expected_acquire.csv'), float_precision='high')
     data_block['Performance_Data'] = pd.read_csv(os.path.join(DATA_DIR, 'instance_performance_sample.csv')).drop_duplicates(

--- a/src/decisionengine_modules/AWS/transforms/FigureOfMerit.py
+++ b/src/decisionengine_modules/AWS/transforms/FigureOfMerit.py
@@ -40,6 +40,7 @@ def figure_of_merit(RunningVms, MaxLimit, PricePerf):
 class FigureOfMerit(Transform.Transform):
     def __init__(self, config):
         super().__init__(config)
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
 
     def transform(self, data_block):
         """
@@ -50,7 +51,7 @@ class FigureOfMerit(Transform.Transform):
 
         :rtype: pandas frame (:class:`pd.DataFramelist`)
         """
-
+        self.logger.debug("in FigureOfMerit transform")
         spot_price_data = self.provisioner_resource_spot_prices(data_block)
         perf_data = self.Performance_Data(data_block)
         occup_data = self.AWS_Occupancy(data_block)

--- a/src/decisionengine_modules/GCE/publishers/GCEBurnRatePublisher.py
+++ b/src/decisionengine_modules/GCE/publishers/GCEBurnRatePublisher.py
@@ -11,8 +11,10 @@ from decisionengine_modules.graphite.publishers.generic_publisher import Generic
 class GCEBurnRatePublisher(publisher):
     def __init__(self, config):
         super().__init__(config)
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
 
     def graphite_context(self, dataframe):
+        self.logger.debug("in GCEBurnRatePublisher graphite_context")
         d = {}
         # Only one row in this data frame
         d['hepcloud-fnal.BurnRate'] = dataframe.loc[0, 'BurnRate'].item()

--- a/src/decisionengine_modules/GCE/publishers/GCEFigureOfMerit_publisher.py
+++ b/src/decisionengine_modules/GCE/publishers/GCEFigureOfMerit_publisher.py
@@ -12,8 +12,10 @@ import decisionengine_modules.graphite_client as graphite
 class GCEFigureOfMeritPublisher(publisher):
     def __init__(self, config):
         super().__init__(config)
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
 
     def graphite_context(self, dataframe):
+        self.logger.debug("in GCEFigureOfMeritPublisher graphite_context")
         d = {}
         for i, row in dataframe.iterrows():
             key = ('%s.fig_of_merit' %

--- a/src/decisionengine_modules/GCE/publishers/GCEPricePerformance_publisher.py
+++ b/src/decisionengine_modules/GCE/publishers/GCEPricePerformance_publisher.py
@@ -11,8 +11,10 @@ import decisionengine_modules.graphite_client as graphite
 class GCEPricePerformancePublisher(publisher):
     def __init__(self, config):
         super().__init__(config)
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
 
     def graphite_context(self, dataframe):
+        self.logger.debug("in GCEPricePerformancePublisher graphite_context")
         d = {}
         for i, row in dataframe.iterrows():
             key = ('%s.price_perf' % (graphite.sanitize_key(row['EntryName'])))

--- a/src/decisionengine_modules/GCE/sources/GCEBillingInfo.py
+++ b/src/decisionengine_modules/GCE/sources/GCEBillingInfo.py
@@ -1,4 +1,3 @@
-import structlog
 import pandas as pd
 
 from decisionengine.framework.modules import Source
@@ -32,8 +31,7 @@ class GCEBillingInfo(Source.Source):
         self.botoConfig = config.get('botoConfig')  # BOTO_CONFIG env
         # location for downloaded billing files
         self.localFileDir = config.get('localFileDir')
-
-        self.logger = structlog.getLogger()
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
 
     def acquire(self):
         """
@@ -41,6 +39,7 @@ class GCEBillingInfo(Source.Source):
 
         :rtype: :obj:`~pd.DataFrame`
         """
+        self.logger.debug("in GCEBillingInfo acquire")
         constantsDict = {'projectId': self.projectId, 'credentialsProfileName': self.credentialsProfileName, 'accountNumber': self.accountNumber,
                          'bucketBillingName': 'billing-' + str(self.projectId), 'lastKnownBillDate': self.lastKnownBillDate,
                          'balanceAtDate': self.balanceAtDate, 'applyDiscount': self.applyDiscount}

--- a/src/decisionengine_modules/GCE/sources/GCEInstancePerformance.py
+++ b/src/decisionengine_modules/GCE/sources/GCEInstancePerformance.py
@@ -14,11 +14,13 @@ class GCEInstancePerformance(Source.Source):
 
     def __init__(self, config):
         super().__init__(config)
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
         self.csv_file = config.get('csv_file')
         if not self.csv_file:
             raise RuntimeError("No csv file found in configuration")
 
     def acquire(self):
+        self.logger.debug("in GCEInstancePerformance acquire")
         return {'GCE_Instance_Performance': pd.read_csv(self.csv_file)}
 
 

--- a/src/decisionengine_modules/GCE/sources/GCEResourceLimits.py
+++ b/src/decisionengine_modules/GCE/sources/GCEResourceLimits.py
@@ -16,6 +16,7 @@ class GCEResourceLimits(SourceProxy.SourceProxy):
 
     def __init__(self, config):
         super().__init__(config)
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
         self.entry_limit_attrs = config.get('entry_limit_attrs')
         if len(self.data_keys) != 1:
             raise RuntimeError("Only one element may be specified in the 'Dataproducts' parameter.")
@@ -27,6 +28,7 @@ class GCEResourceLimits(SourceProxy.SourceProxy):
         :rtype: :obj:`~pd.DataFrame`
         """
 
+        self.logger.debug("in GCEResourceLimits acquire")
         factory_data = super().acquire()
         assert len(factory_data) == 1
         df_factory_data = factory_data.popitem()[1]

--- a/src/decisionengine_modules/GCE/sources/GceOccupancy.py
+++ b/src/decisionengine_modules/GCE/sources/GceOccupancy.py
@@ -37,11 +37,13 @@ class GceOccupancy(Source.Source):
             cache_discovery=use_cache)
         self.max_retries = config.get("max_retries", _MAX_RETRIES)
         self.retry_timeout = config.get("retry_timeout", _RETRY_TIMEOUT)
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
 
     def _get_client(self):
         return self.client
 
     def acquire(self):
+        self.logger.debug("in GCEOccupancy acquire")
         return retry_wrapper(self._acquire, self.max_retries, self.retry_timeout, backoff=False)
 
     def _acquire(self):

--- a/src/decisionengine_modules/GCE/transforms/GceBurnRate.py
+++ b/src/decisionengine_modules/GCE/transforms/GceBurnRate.py
@@ -12,8 +12,10 @@ from decisionengine.framework.modules import Transform
 class GceBurnRate(Transform.Transform):
     def __init__(self, config):
         super().__init__(config)
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
 
     def transform(self, data_block):
+        self.logger.debug("in GceBurnRate transform")
         performance = self.GCE_Instance_Performance(data_block).fillna(0)
         occupancy = self.GCE_Occupancy(data_block).fillna(0)
 

--- a/src/decisionengine_modules/GCE/transforms/GceFigureOfMerit.py
+++ b/src/decisionengine_modules/GCE/transforms/GceFigureOfMerit.py
@@ -19,9 +19,11 @@ from decisionengine_modules.util.figure_of_merit import figure_of_merit
 class GceFigureOfMerit(Transform.Transform):
     def __init__(self, config):
         super().__init__(config)
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
 
     def transform(self, data_block):
 
+        self.logger.debug("in GceFigureOfMerit transform")
         performance = self.GCE_Instance_Performance(data_block)
         performance["PricePerformance"] = np.where(performance["PerfTtbarTotal"] > 0,
                                                    (performance["OnDemandPrice"] /

--- a/src/decisionengine_modules/NERSC/publishers/NerscFigureOfMerit_publisher.py
+++ b/src/decisionengine_modules/NERSC/publishers/NerscFigureOfMerit_publisher.py
@@ -12,8 +12,10 @@ import decisionengine_modules.graphite_client as graphite
 class NerscFigureOfMeritPublisher(publisher):
     def __init__(self, config):
         super().__init__(config)
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
 
     def graphite_context(self, dataframe):
+        self.logger.debug("in NerscFigureOfMeritPublisher graphite_context")
         d = {}
         for i, row in dataframe.iterrows():
             key = ('%s.fig_of_merit' %

--- a/src/decisionengine_modules/NERSC/sources/NerscAllocationInfo.py
+++ b/src/decisionengine_modules/NERSC/sources/NerscAllocationInfo.py
@@ -2,7 +2,6 @@
 Get allocation info from Nersc
 """
 import pandas as pd
-import structlog
 
 from decisionengine.framework.modules import Source
 from decisionengine.framework.modules.Source import Parameter
@@ -47,7 +46,7 @@ class NerscAllocationInfo(Source.Source):
             config.get('passwd_file'),
             num_retries=self.max_retries,
             retry_backoff_factor=self.retry_backoff_factor)
-        self.logger = structlog.getLogger()
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
 
     def send_query(self):
         """
@@ -83,6 +82,7 @@ class NerscAllocationInfo(Source.Source):
         Acquire NERSC allocation info and return as pandas frame
         :rtype: :obj:`~pd.DataFrame`
         """
+        self.logger.debug("in NerscAllocationInfo acquire")
         return {'Nersc_Allocation_Info': pd.DataFrame(self.send_query())}
 
 

--- a/src/decisionengine_modules/NERSC/sources/NerscInstancePerformance.py
+++ b/src/decisionengine_modules/NERSC/sources/NerscInstancePerformance.py
@@ -13,11 +13,13 @@ class NerscInstancePerformance(Source.Source):
 
     def __init__(self, config):
         super().__init__(config)
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
         self.csv_file = config.get('csv_file')
         if not self.csv_file:
             raise RuntimeError("No csv file found in configuration")
 
     def acquire(self):
+        self.logger.debug("in NerscInstancePerformance acquire")
         return {'Nersc_Instance_Performance': pd.read_csv(self.csv_file)}
 
 

--- a/src/decisionengine_modules/NERSC/sources/NerscJobInfo.py
+++ b/src/decisionengine_modules/NERSC/sources/NerscJobInfo.py
@@ -1,6 +1,5 @@
 """ Get job info from Nersc
 """
-import structlog
 import pandas as pd
 
 from decisionengine.framework.modules import Source
@@ -33,6 +32,7 @@ class NerscJobInfo(Source.Source):
 
     def __init__(self, config):
         super().__init__(config)
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
         self.constraints = config.get('constraints')
         self.max_retries = config.get("max_retries", _MAX_RETRIES)
         self.retry_backoff_factor = config.get("retry_backoff_factor", _RETRY_BACKOFF_FACTOR)
@@ -40,7 +40,6 @@ class NerscJobInfo(Source.Source):
             config.get('passwd_file'),
             num_retries=self.max_retries,
             retry_backoff_factor=self.retry_backoff_factor)
-        self.logger = structlog.getLogger()
 
     def acquire(self):
         """
@@ -49,6 +48,7 @@ class NerscJobInfo(Source.Source):
         Acquire NERSC job info and return as pandas frame
         :return: `dict`
         """
+        self.logger.debug("in NerscJobInfo acquire")
         raw_results = []
         # By default, query edison and cori
         self.constraints['machines'] = self.constraints.get('machines',

--- a/src/decisionengine_modules/NERSC/transforms/CompareNerscFactoryJobs.py
+++ b/src/decisionengine_modules/NERSC/transforms/CompareNerscFactoryJobs.py
@@ -4,7 +4,6 @@ Compare jobs on factory and Nersc
 
 import pandas as pd
 
-import structlog
 from decisionengine.framework.modules import Transform
 
 @Transform.consumes(job_manifests=pd.DataFrame,
@@ -17,7 +16,8 @@ class CompareNerscFactoryJobs(Transform.Transform):
     """
 
     def __init__(self, param_dict):
-        self.logger = structlog.getLogger()
+        super().__init__(param_dict)
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
 
     def transform(self, data_block):
         """
@@ -25,6 +25,7 @@ class CompareNerscFactoryJobs(Transform.Transform):
         comparison results, as # jobs in both, # jobs in factory/Nersc only, # jobs
         running on Nersc, and # jobs in factory without an ID.
         """
+        self.logger.debug("in CompareNerscFactoryJobs transform")
         nersc_df = data_block['Nersc_Job_Info']
         factory_df = data_block['job_manifests']
 

--- a/src/decisionengine_modules/NERSC/transforms/CompareNerscUserpoolSlots.py
+++ b/src/decisionengine_modules/NERSC/transforms/CompareNerscUserpoolSlots.py
@@ -2,7 +2,6 @@
 Compare slots on Nersc and startd
 """
 import pandas
-import structlog
 
 from decisionengine.framework.modules import Transform
 from decisionengine.framework.modules.Transform import Parameter
@@ -22,8 +21,9 @@ class CompareNerscUserpoolSlots(Transform.Transform):
     """
 
     def __init__(self, param_dict):
+        super().__init__(config)
         self.entry_nersc_map = param_dict['entry_nersc_map']
-        self.logger = structlog.getLogger()
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
 
     def transform(self, data_block):
         """
@@ -31,6 +31,7 @@ class CompareNerscUserpoolSlots(Transform.Transform):
         compare the two metrics. Also calculate the relative difference between them.
         """
 
+        self.logger.debug("in CompareNerscUserpoolSlots transform")
         nersc_df = data_block['Nersc_Job_Info']
         userpool_slots_df = data_block['startd_manifests']
         factory_entry_df = data_block['Factory_Entries_LCF']

--- a/src/decisionengine_modules/NERSC/transforms/NerscFigureOfMerit.py
+++ b/src/decisionengine_modules/NERSC/transforms/NerscFigureOfMerit.py
@@ -9,7 +9,6 @@ import sys
 
 from decisionengine.framework.modules import Transform
 from decisionengine_modules.util import figure_of_merit as fom
-import structlog
 
 
 @Transform.consumes(Nersc_Instance_Performance=pd.DataFrame,
@@ -19,7 +18,7 @@ import structlog
 class NerscFigureOfMerit(Transform.Transform):
     def __init__(self, config):
         super().__init__(config)
-        self.logger = structlog.getLogger()
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
 
     def transform(self, data_block):
         """
@@ -43,6 +42,7 @@ class NerscFigureOfMerit(Transform.Transform):
 
         """
 
+        self.logger.debug("in NerscFigureOfMerit transform")
         performance = self.Nersc_Instance_Performance(data_block)
         performance["PricePerformance"] = np.where(performance["PerfTtbarTotal"] > 0,
                                                    (performance["OnDemandPrice"] /

--- a/src/decisionengine_modules/NERSC/util/newt.py
+++ b/src/decisionengine_modules/NERSC/util/newt.py
@@ -49,8 +49,7 @@ class Newt:
         retry = Retry(
             status=self.num_retries,
             status_forcelist=[500, 502, 503, 504, 507],
-            backoff_factor=self.retry_backoff_factor,
-            allowed_methods=False)
+            backoff_factor=self.retry_backoff_factor)
         retry_adapter = HTTPAdapter(max_retries=retry)
         self.session.mount(self.newt_base_url, retry_adapter)
 

--- a/src/decisionengine_modules/glideinwms/glide_frontend_element.py
+++ b/src/decisionengine_modules/glideinwms/glide_frontend_element.py
@@ -12,9 +12,7 @@ from glideinwms.lib import pubCrypto
 from decisionengine_modules.glideinwms import classads
 from decisionengine_modules.glideinwms.security import Credential
 from decisionengine_modules.glideinwms.security import CredentialCache
-
-logger = structlog.getLogger()
-
+from decisionengine.framework.modules.logging_configDict import CHANNELLOGGERNAME
 
 pandas.options.mode.chained_assignment = None  # default='warn'
 
@@ -44,7 +42,8 @@ class GlideFrontendElement:
     """
 
     def __init__(self, fe_group, acct_group, fe_cfg):
-        self.logger = structlog.getLogger()
+        self.logger = structlog.getLogger(CHANNELLOGGERNAME)
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], channel="")
         self.fe_group = fe_group
         self.acct_group = acct_group
         self.fe_cfg = fe_cfg

--- a/src/decisionengine_modules/glideinwms/publishers/decisionenginemonitor.py
+++ b/src/decisionengine_modules/glideinwms/publishers/decisionenginemonitor.py
@@ -8,9 +8,10 @@ class DecisionEngineMonitorManifests(publisher.HTCondorManifests):
     def __init__(self, config):
         super().__init__(config)
         self.classad_type = 'glideclientmonitor'
-
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
 
     def create_invalidate_constraint(self, requests_df):
+        self.logger.debug("in DecisionEngineMonitorManifests create_invalidate_constraint")
         for collector_host, request_group in requests_df.groupby(['CollectorHost']):
             client_names = list(set(request_group['GlideClientName']))
             client_names.sort()

--- a/src/decisionengine_modules/glideinwms/publishers/fe_group_classads.py
+++ b/src/decisionengine_modules/glideinwms/publishers/fe_group_classads.py
@@ -1,6 +1,5 @@
 import pandas
 
-import structlog
 from decisionengine.framework.modules import Publisher
 from decisionengine_modules.htcondor.publishers import publisher
 
@@ -18,7 +17,7 @@ class GlideinWMSManifests(publisher.HTCondorManifests):
 
     def __init__(self, config):
         super().__init__(config)
-        self.logger = structlog.getLogger()
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
         self._fact_entrytype_map = {
             'allow_grid_requests': 'Factory_Entries_Grid',
             'allow_aws_requests': 'Factory_Entries_AWS',
@@ -28,6 +27,7 @@ class GlideinWMSManifests(publisher.HTCondorManifests):
         self.classad_type = 'glideclient'
 
     def publish(self, datablock):
+        self.logger.debug("in GlideinWMSManifests publish")
         requests_df = datablock.get('glideclient_manifests')
         facts_df = datablock.get('de_logicengine_facts')
 

--- a/src/decisionengine_modules/glideinwms/publishers/glideclientglobal.py
+++ b/src/decisionengine_modules/glideinwms/publishers/glideclientglobal.py
@@ -8,9 +8,10 @@ class GlideClientGlobalManifests(publisher.HTCondorManifests):
     def __init__(self, config):
         super().__init__(config)
         self.classad_type = 'glideclientglobal'
-
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
 
     def create_invalidate_constraint(self, dataframe):
+        self.logger.debug("in GlideClientGlobalManifests create_invalidate_constraint")
         for collector_host, group in dataframe.groupby(['CollectorHost']):
             client_names = list(set(group['ClientName']))
             client_names.sort()

--- a/src/decisionengine_modules/glideinwms/publishers/gwms_to_aws_data.py
+++ b/src/decisionengine_modules/glideinwms/publishers/gwms_to_aws_data.py
@@ -15,6 +15,7 @@ class AWSFactoryEntryDataPublisher(Publisher.Publisher):
 
     def __init__(self, config):
         super().__init__(config)
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
         self.aws_instance_limits_file = config.get('aws_instance_limits')
         self.spot_occupancy_config_file = config.get('spot_occupancy_config')
 
@@ -22,6 +23,7 @@ class AWSFactoryEntryDataPublisher(Publisher.Publisher):
             raise RuntimeError('parameters for module config is missing spot_occupancy_config or aws_instance_limits')
 
     def publish(self, datablock):
+        self.logger.debug("in AWSFactoryEntryDataPublisher publish")
         limits_df = self.aws_instance_limits(datablock)
         so_config = self.spot_occupancy_config(datablock).to_dict()
 

--- a/src/decisionengine_modules/glideinwms/publishers/job_clustering_publisher.py
+++ b/src/decisionengine_modules/glideinwms/publishers/job_clustering_publisher.py
@@ -6,13 +6,14 @@ from decisionengine.framework.modules import Publisher
 from decisionengine_modules.graphite.publishers.generic_publisher import GenericPublisher as publisher
 import decisionengine_modules.graphite_client as graphite
 
-
 @publisher.consumes_dataframe('job_clusters')
 class JobClusteringPublisher(publisher):
     def __init__(self, config):
         super().__init__(config)
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
 
     def graphite_context(self, dataframe):
+        self.logger.debug("in JobClusteringPublisher graphite_context")
         d = {}
         for i, row in dataframe.iterrows():
             key = ('%s.job_cluster' %

--- a/src/decisionengine_modules/glideinwms/resource_dist_plugins.py
+++ b/src/decisionengine_modules/glideinwms/resource_dist_plugins.py
@@ -1,7 +1,10 @@
 import structlog
 import pandas
 
-logger = structlog.getLogger()
+from decisionengine.framework.modules.logging_configDict import CHANNELLOGGERNAME
+
+logger = structlog.getLogger(CHANNELLOGGERNAME)
+logger = logger.bind(module=__name__.split(".")[-1], channel="")
 
 _RESOURCE_FROM_COLUMN_MAP = {
     'Grid_Figure_Of_Merit': 'Grid_Figure_Of_Merit',

--- a/src/decisionengine_modules/glideinwms/security.py
+++ b/src/decisionengine_modules/glideinwms/security.py
@@ -6,8 +6,10 @@ from glideinwms.lib import x509Support
 from glideinwms.lib import condorExe
 
 import structlog
+from decisionengine.framework.modules.logging_configDict import CHANNELLOGGERNAME
 
-logger = structlog.getLogger()
+logger = structlog.getLogger(CHANNELLOGGERNAME)
+logger = logger.bind(module=__name__.split(".")[-1], channel="")
 
 
 class Credential:

--- a/src/decisionengine_modules/glideinwms/sources/factory_client.py
+++ b/src/decisionengine_modules/glideinwms/sources/factory_client.py
@@ -11,9 +11,10 @@ class FactoryClientManifests(source.ResourceManifests):
         super().__init__(config)
         self.constraint = '(%s)&&(glideinmytype=="glidefactoryclient")' % self.constraint
         self.subsystem_name = 'any'
-
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
 
     def acquire(self):
+        self.logger.debug("in FactoryClientManifests acquire")
         return {'factoryclient_manifests': self.load()}
 
 

--- a/src/decisionengine_modules/glideinwms/sources/factory_entries.py
+++ b/src/decisionengine_modules/glideinwms/sources/factory_entries.py
@@ -1,5 +1,4 @@
 from functools import partial
-import structlog
 import pandas
 
 from decisionengine.framework.modules import Source
@@ -27,6 +26,7 @@ from decisionengine_modules.htcondor import htcondor_query
 class FactoryEntries(Source.Source):
 
     def __init__(self, config):
+        super().__init__(config)
         self.condor_config = config.get('condor_config')
         self.factories = config.get('factories', [])
         self._entry_gridtype_map = {
@@ -42,7 +42,7 @@ class FactoryEntries(Source.Source):
         self.retry_interval = config.get('retry_interval', 0)
 
         self.subsystem_name = 'any'
-        self.logger = structlog.getLogger()
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
 
     def acquire(self):
         """
@@ -51,6 +51,7 @@ class FactoryEntries(Source.Source):
         :rtype: :obj:`~pd.DataFrame`
         """
 
+        self.logger.debug("in FactoryEntries acquire")
         dataframe = pandas.DataFrame()
 
         for factory in self.factories:

--- a/src/decisionengine_modules/glideinwms/sources/factory_global.py
+++ b/src/decisionengine_modules/glideinwms/sources/factory_global.py
@@ -1,5 +1,4 @@
 from functools import partial
-import structlog
 
 import pandas
 
@@ -30,6 +29,7 @@ class FactoryGlobalManifests(Source.Source):
         if not isinstance(config, dict):
             raise RuntimeError('parameters for module config should be a dict')
 
+        super().__init__(config)
         self.condor_config = config.get('condor_config')
         self.factories = config.get('factories', [])
 
@@ -39,7 +39,7 @@ class FactoryGlobalManifests(Source.Source):
         self.retry_interval = config.get('retry_interval', 0)
 
         self.subsystem_name = 'any'
-        self.logger = structlog.getLogger()
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
 
     def acquire(self):
         """
@@ -48,6 +48,7 @@ class FactoryGlobalManifests(Source.Source):
         :rtype: :obj:`~pd.DataFrame`
         """
 
+        self.logger.debug("in FactoryGlobalManifests acquire")
         dataframe = None
 
         for factory in self.factories:

--- a/src/decisionengine_modules/glideinwms/transforms/glidein_requests.py
+++ b/src/decisionengine_modules/glideinwms/transforms/glidein_requests.py
@@ -1,7 +1,6 @@
 import os.path
 import pandas
 import numpy
-import structlog
 
 from decisionengine.framework.modules import Transform
 from decisionengine.framework.modules.Transform import Parameter
@@ -50,8 +49,8 @@ class GlideinRequestManifests(Transform.Transform):
         self.de_frontend_configfile = config.get(
             'de_frontend_config',
             '/var/lib/gwms-frontend/vofrontend/de_frontend_config')
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
 
-        self.logger = structlog.getLogger()
 
     def transform(self, datablock):
         """
@@ -64,6 +63,7 @@ class GlideinRequestManifests(Transform.Transform):
         """
 
         # Dict to be returned
+        self.logger.debug("in GlideinRequestManifests transform")
         manifests = {}
 
         try:

--- a/src/decisionengine_modules/glideinwms/transforms/grid_figure_of_merit.py
+++ b/src/decisionengine_modules/glideinwms/transforms/grid_figure_of_merit.py
@@ -1,6 +1,5 @@
 import pandas
 
-import structlog
 from decisionengine.framework.modules import Transform
 from decisionengine.framework.modules.Transform import Parameter
 from decisionengine_modules.util.figure_of_merit import figure_of_merit
@@ -16,7 +15,7 @@ class GridFigureOfMerit(Transform.Transform):
 
     def __init__(self, config):
         super().__init__(config)
-        self.logger = structlog.getLogger()
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
         self.price_performance = config.get('price_performance', 1)
 
     def transform(self, datablock):
@@ -24,6 +23,7 @@ class GridFigureOfMerit(Transform.Transform):
         Grid sites FOM are straight up assumed as 0 for now
         """
 
+        self.logger.debug("in GridFigureOfMerit transform")
         entries = self.Factory_Entries_Grid(datablock)
         if entries is None:
             entries = pandas.DataFrame({ATTR_ENTRYNAME: []})

--- a/src/decisionengine_modules/glideinwms/transforms/gwms_to_aws_data.py
+++ b/src/decisionengine_modules/glideinwms/transforms/gwms_to_aws_data.py
@@ -14,9 +14,14 @@ _ATTR_TRANSLATION_MAP = {
                     spot_occupancy_config=pd.DataFrame)
 class AWSFactoryEntryData(Transform.Transform):
 
+    def __init__(self, config):
+        super().__init__(config)
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
+
     def transform(self, datablock):
 
         # Get the dataframe containing AWS entries
+        self.logger.debug("in AWSFactoryEntryData transform")
         aws_entries = self.Factory_Entries_AWS(datablock)
 
         limits_df = pd.DataFrame()

--- a/src/decisionengine_modules/glideinwms/transforms/job_clustering.py
+++ b/src/decisionengine_modules/glideinwms/transforms/job_clustering.py
@@ -1,6 +1,5 @@
 import pandas
 
-import structlog
 from decisionengine.framework.modules import Transform
 from decisionengine.framework.modules.Transform import Parameter
 
@@ -8,6 +7,16 @@ from decisionengine.framework.modules.Transform import Parameter
 # - what debugging logs are needed?
 # - what and how is metadata for a dataframe?
 # - do we need to validate case or type for attr content?  again onboarding?
+
+class TestData:
+
+    def __init__(self, data):
+
+        self.data = data
+
+    def print_data(self):
+        logger.info("TestData is 5")
+
 
 @Transform.supports_config(Parameter('match_expressions',
                                      default={"VO_Name=='cms' and RequestCpus==1 and (MaxWallTimeMins>0 and MaxWallTimeMins<= 60*12)":
@@ -32,7 +41,7 @@ class JobClustering(Transform.Transform):
                                                   columns=['Job_Bucket_Criteria_Expr', 'Site_Bucket_Criteria_Expr',
                                                            'Totals', 'Frontend_Group'])
 
-        self.logger = structlog.getLogger()
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
 
     def transform(self, datablock):
 

--- a/src/decisionengine_modules/graphite/publishers/generic_publisher.py
+++ b/src/decisionengine_modules/graphite/publishers/generic_publisher.py
@@ -3,7 +3,6 @@ Generic publisher for graphana
 
 """
 import abc
-import structlog
 import pandas
 
 from decisionengine.framework.modules import Publisher
@@ -23,12 +22,13 @@ DEFAULT_GRAPHITE_CONTEXT = ""
 class GenericPublisher(Publisher.Publisher, metaclass=abc.ABCMeta):
 
     def __init__(self, config):
+        super().__init__(config)
         self.graphite_host = config.get('graphite_host', DEFAULT_GRAPHITE_HOST)
         self.graphite_port = config.get('graphite_port', DEFAULT_GRAPHITE_PORT)
         self.graphite_context_header = config.get('graphite_context', DEFAULT_GRAPHITE_CONTEXT)
         self.publish_to_graphite = config.get('publish_to_graphite')
         self.output_file = config.get('output_file')
-        self.logger = structlog.getLogger()
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
 
     @classmethod
     def consumes_dataframe(cls, product_name):
@@ -50,6 +50,7 @@ class GenericPublisher(Publisher.Publisher, metaclass=abc.ABCMeta):
         :arg data_block: data block
 
         """
+        self.logger.debug("in Graphite GenericPublisher publish")
         if not self._consumes:
             return
         product = list(self._consumes.keys())[0]

--- a/src/decisionengine_modules/graphite_client.py
+++ b/src/decisionengine_modules/graphite_client.py
@@ -3,6 +3,7 @@ import pickle
 import struct
 import socket
 import structlog
+from decisionengine.framework.modules.logging_configDict import CHANNELLOGGERNAME
 
 
 def sanitize_key(key):
@@ -21,7 +22,8 @@ class Graphite:
     def __init__(self, host="fifemondata.fnal.gov", pickle_port=2004):
         self.graphite_host = host
         self.graphite_pickle_port = pickle_port
-        self.logger = structlog.getLogger()
+        self.logger = structlog.getLogger(CHANNELLOGGERNAME)
+        self.logger = self.logger.bind(module_class=__name__.split(".")[-1], channel="")
 
     def send_dict(self, namespace, data, debug_print=True, send_data=True):
         """send data contained in dictionary as {k: v} to graphite dataset

--- a/src/decisionengine_modules/htcondor/htcondor_query.py
+++ b/src/decisionengine_modules/htcondor/htcondor_query.py
@@ -5,7 +5,10 @@ import structlog
 import os
 import sys
 
-logger = structlog.getLogger()
+from decisionengine.framework.modules.logging_configDict import CHANNELLOGGERNAME
+
+logger = structlog.getLogger(CHANNELLOGGERNAME)
+logger = logger.bind(module=__name__.split(".")[-1], channel="")
 
 
 class QueryError(RuntimeError):
@@ -154,7 +157,7 @@ class CondorStatus(CondorQuery):
         """
         Fetch resource classads and return a list of evaluated classads
         """
-
+        logger.debug("in CondorStatus fetch")
         results = []
         constraint = bindings_friendly_constraint(constraint)
         attrs = bindings_friendly_attrs(format_list)

--- a/src/decisionengine_modules/htcondor/publishers/publisher.py
+++ b/src/decisionengine_modules/htcondor/publishers/publisher.py
@@ -1,7 +1,6 @@
 import abc
 import classad
 import htcondor
-import structlog
 import os
 import pandas
 from functools import partial
@@ -20,11 +19,12 @@ DEFAULT_INVALIDATE_AD_COMMAND = 'INVALIDATE_AD_GENERIC'
 class HTCondorManifests(Publisher.Publisher, metaclass=abc.ABCMeta):
 
     def __init__(self, config):
+        super().__init__(config)
         self.condor_config = config.get('condor_config')
         self.x509_user_proxy = config.get('x509_user_proxy')
         self.nretries = config.get('nretries')
         self.retry_interval = config.get('retry_interval')
-        self.logger = structlog.getLogger()
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
         self.update_ad_command = DEFAULT_UPDATE_AD_COMMAND
         self.invalidate_ad_command = DEFAULT_INVALIDATE_AD_COMMAND
         self.classad_type = 'generic'
@@ -119,6 +119,7 @@ class HTCondorManifests(Publisher.Publisher, metaclass=abc.ABCMeta):
 
         :type datablock: :obj:`DataBlock`
         """
+        self.logger.debug("in HTCondorManifests publish")
         for key in self._consumes:
             dataframe = datablock.get(key)
             self.publish_to_htcondor(key, dataframe)

--- a/src/decisionengine_modules/htcondor/sources/job_q.py
+++ b/src/decisionengine_modules/htcondor/sources/job_q.py
@@ -1,11 +1,9 @@
-import structlog
 import pandas
 import traceback
 
 from decisionengine.framework.modules import Source
 from decisionengine.framework.modules.Source import Parameter
 from decisionengine_modules.htcondor import htcondor_query
-
 
 @Source.supports_config(Parameter('collector_host', type=str),
                         Parameter('schedds', default=[None]),
@@ -23,13 +21,12 @@ class JobQ(Source.Source):
         and values that the operators want to be default values for the classad_attrs.
         """
         super().__init__(config)
-
         self.collector_host = config.get('collector_host')
         self.schedds = config.get('schedds', [None])
         self.condor_config = config.get('condor_config')
         self.constraint = config.get('constraint', True)
         self.classad_attrs = config.get('classad_attrs')
-        self.logger = structlog.getLogger()
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1])
         self.correction_map = config.get('correction_map')
 
     def acquire(self):
@@ -37,6 +34,7 @@ class JobQ(Source.Source):
         Acquire jobs from the HTCondor Schedd
         :rtype: :obj:`~pd.DataFrame`
         """
+        self.logger.debug("in JobQ acquire")
         dataframe = pandas.DataFrame()
         (collector_host, secondary_collectors) = htcondor_query.split_collector_host(
             self.collector_host)

--- a/src/decisionengine_modules/htcondor/sources/slots.py
+++ b/src/decisionengine_modules/htcondor/sources/slots.py
@@ -7,7 +7,12 @@ from decisionengine.framework.modules import Source
 @Source.produces(startd_manifests=pandas.DataFrame)
 class StartdManifests(source.ResourceManifests):
 
+    def __init__(self, config):
+        super().__init__(config)
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
+
     def acquire(self):
+        self.logger.debug("in StartdManifests acquire")
         return {'startd_manifests': self.load()}
 
 

--- a/src/decisionengine_modules/htcondor/sources/source.py
+++ b/src/decisionengine_modules/htcondor/sources/source.py
@@ -1,7 +1,6 @@
 import abc
 import traceback
 import pandas
-import structlog
 
 from decisionengine.framework.modules import Source
 from decisionengine.framework.modules.Source import Parameter
@@ -27,7 +26,7 @@ class ResourceManifests(Source.Source, metaclass=abc.ABCMeta):
         avaiable in its config file.
         """
         super(Source.Source, self).__init__(config)
-        self.logger = structlog.getLogger()
+        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
         self.collector_host = config.get('collector_host')
         self.condor_config = config.get('condor_config')
         self.constraint = config.get('constraint', True)
@@ -59,6 +58,7 @@ class ResourceManifests(Source.Source, metaclass=abc.ABCMeta):
         :rtype: :obj:`~pd.DataFrame`
         """
 
+        self.logger.debug("in ResourceManifests load")
         dataframe = pandas.DataFrame()
         try:
             condor_status = htcondor_query.CondorStatus(

--- a/src/decisionengine_modules/load_config.py
+++ b/src/decisionengine_modules/load_config.py
@@ -1,12 +1,13 @@
 import time
 import structlog
+from decisionengine.framework.modules.logging_configDict import CHANNELLOGGERNAME
 
 """
 Load python object
 """
 
-logger = structlog.getLogger()
-
+logger = structlog.getLogger(CHANNELLOGGERNAME)
+logger = logger.bind(module=__name__.split(".")[-1], channel="")
 
 def load(python_file, retries=0, timeout=0):
     """

--- a/src/decisionengine_modules/tests/etc/decisionengine/config.d/channelA.conf
+++ b/src/decisionengine_modules/tests/etc/decisionengine/config.d/channelA.conf
@@ -68,7 +68,7 @@
         "schedule": 320,
     },
     "LocalCapacity" : {
-        "module" : "decisionengine_modules.AWS.LocalCapacity",
+        "module" : "decisionengine_modules.AWS.sources.LocalCapacity",
         "name"   : "LocalCapacity",
         "parameters" : {
             "collector_name": "cmscollector.fnal.gov",

--- a/src/decisionengine_modules/tests/glideinwms/publishers/test_decisionenginemonitor.py
+++ b/src/decisionengine_modules/tests/glideinwms/publishers/test_decisionenginemonitor.py
@@ -6,6 +6,7 @@ from decisionengine_modules.glideinwms.publishers import decisionenginemonitor
 
 
 config = {
+    'channel_name': "test",
     'condor_config': 'condor_config',
     'collector_host': 'fermicloud122.fnal.gov',
 }

--- a/src/decisionengine_modules/tests/glideinwms/publishers/test_fe_group_classads.py
+++ b/src/decisionengine_modules/tests/glideinwms/publishers/test_fe_group_classads.py
@@ -6,6 +6,7 @@ from decisionengine_modules.glideinwms.publishers import fe_group_classads
 
 
 config = {
+    'channel_name': "test",
     'condor_config': 'condor_config',
     'collector_host': 'fermicloud122.fnal.gov',
 }

--- a/src/decisionengine_modules/tests/glideinwms/publishers/test_glideclientglobal.py
+++ b/src/decisionengine_modules/tests/glideinwms/publishers/test_glideclientglobal.py
@@ -6,6 +6,7 @@ from decisionengine_modules.glideinwms.publishers import glideclientglobal
 
 
 config = {
+    'channel_name': "test",
     'condor_config': 'condor_config',
     'collector_host': 'fermicloud122.fnal.gov',
 }

--- a/src/decisionengine_modules/tests/test_AwsBurnRate.py
+++ b/src/decisionengine_modules/tests/test_AwsBurnRate.py
@@ -6,8 +6,7 @@ from decisionengine_modules.AWS.transforms import AwsBurnRate
 
 produces = {"AWS_Burn_Rate": pd.DataFrame}
 
-config = {
-}
+config = {"channel_name": "test"}
 
 occupancy = pd.DataFrame([
     {

--- a/src/decisionengine_modules/tests/test_GCEFigureOfMerit_publisher.py
+++ b/src/decisionengine_modules/tests/test_GCEFigureOfMerit_publisher.py
@@ -3,7 +3,8 @@ import pandas
 
 from decisionengine_modules.GCE.publishers import GCEFigureOfMerit_publisher
 
-config_fom_pub = {"publish_to_graphite": True,
+config_fom_pub = {"channel_name": "test",
+                  "publish_to_graphite": True,
                   "graphite_host": "lsdataitb.fnal.gov",
                   "graphite_port": 2004,
                   "graphite_context": "hepcloud.de.gce",

--- a/src/decisionengine_modules/tests/test_GCEInstancePerformanceInfo.py
+++ b/src/decisionengine_modules/tests/test_GCEInstancePerformanceInfo.py
@@ -8,9 +8,7 @@ from decisionengine.framework.modules.Module import verify_products
 DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 CSV_FILE = os.path.join(DATA_DIR, "instance_performance_google.csv")
 
-CONFIG = {
-    "csv_file": CSV_FILE,
-}
+CONFIG = {"channel_name": "test", "csv_file": CSV_FILE}
 
 EXPECTED_PANDAS_DF = pd.read_csv(CONFIG.get("csv_file"))
 

--- a/src/decisionengine_modules/tests/test_GCEPricePerformance_publisher.py
+++ b/src/decisionengine_modules/tests/test_GCEPricePerformance_publisher.py
@@ -3,7 +3,8 @@ import pandas
 
 from decisionengine_modules.GCE.publishers import GCEPricePerformance_publisher
 
-config_pp_pub = {"publish_to_graphite": True,
+config_pp_pub = {"channel_name": "test",
+                 "publish_to_graphite": True,
                  "graphite_host": "lsdataitb.fnal.gov",
                  "graphite_port": 2004,
                  "graphite_context": "hepcloud.de.gce",

--- a/src/decisionengine_modules/tests/test_GCEResourceLimits.py
+++ b/src/decisionengine_modules/tests/test_GCEResourceLimits.py
@@ -16,7 +16,7 @@ DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 FIXTURE_FILE = os.path.join(DATA_DIR, "gce_limits_factory_entries.test")
 
 CONFIG = {
-    "channel_name": "factory_data_channel",
+    "source_channel": "factory_data_channel",
     "Dataproducts": ["Factory_Entries_GCE"],
     "retries": 3,
     "retry_timeout": 20,

--- a/src/decisionengine_modules/tests/test_GceBurnRate.py
+++ b/src/decisionengine_modules/tests/test_GceBurnRate.py
@@ -12,8 +12,7 @@ OCCUPANCY = pd.read_csv(CSV_FILE)
 _PRODUCES = ["GCE_Burn_Rate"]
 _PRODUCES_DICT = dict.fromkeys(_PRODUCES, pd.DataFrame)
 
-CONFIG = {
-}
+CONFIG = {"channel_name": "test"}
 
 
 performance = pd.DataFrame([

--- a/src/decisionengine_modules/tests/test_GceFigureOfMerit.py
+++ b/src/decisionengine_modules/tests/test_GceFigureOfMerit.py
@@ -11,8 +11,7 @@ CSV_FILE = os.path.join(DATA_DIR, "GceOccupancy.output.fixture.csv")
 
 _PRODUCES = ["GCE_Price_Performance", "GCE_Figure_Of_Merit"]
 _PRODUCES_DICT = dict.fromkeys(_PRODUCES, pd.DataFrame)
-CONFIG = {
-}
+CONFIG = {"channel_name": "test"}
 
 GCE_OCCUPANCY_DF = pd.read_csv(CSV_FILE)
 

--- a/src/decisionengine_modules/tests/test_GceOccupancy.py
+++ b/src/decisionengine_modules/tests/test_GceOccupancy.py
@@ -14,6 +14,7 @@ CSV_FILE = os.path.join(DATA_DIR, "GceOccupancy.output.fixture.csv")
 EXPECTED_DF = pd.read_csv(CSV_FILE)
 
 CONFIG = {
+    "channel_name": "test",
     "project": "hepcloud-fnal",
     "credential": os.path.join(DATA_DIR, "monitoring.json")
 }

--- a/src/decisionengine_modules/tests/test_NerscAllocationInfo.py
+++ b/src/decisionengine_modules/tests/test_NerscAllocationInfo.py
@@ -15,6 +15,7 @@ PASSWD_FILE = os.path.join(DATA_DIR, "passwd")
 FAKE_USER = "user2"
 
 CONFIG = {
+    "channel_name": "test",
     "passwd_file": PASSWD_FILE,
     "constraints": {
         "usernames": ["timm", FAKE_USER],

--- a/src/decisionengine_modules/tests/test_NerscFigureOfMerit.py
+++ b/src/decisionengine_modules/tests/test_NerscFigureOfMerit.py
@@ -6,8 +6,7 @@ from decisionengine.framework.modules.Module import verify_products
 _produces = ['Nersc_Price_Performance', 'Nersc_Figure_Of_Merit']
 produces = dict.fromkeys(_produces, pd.DataFrame)
 
-config = {
-}
+config = {"channel_name": "test"}
 
 nersc_instance_performance_df = pd.DataFrame([
     {"EntryName": "CMSHTPC_T3_US_NERSC_Cori",

--- a/src/decisionengine_modules/tests/test_NerscFigureOfMerit_publisher.py
+++ b/src/decisionengine_modules/tests/test_NerscFigureOfMerit_publisher.py
@@ -3,7 +3,8 @@ import pandas
 
 from decisionengine_modules.NERSC.publishers import NerscFigureOfMerit_publisher
 
-config_fom_pub = {"publish_to_graphite": True,
+config_fom_pub = {"channel_name": "test",
+                  "publish_to_graphite": True,
                   "graphite_host": "lsdataitb.fnal.gov",
                   "graphite_port": 2004,
                   "graphite_context": "hepcloud.de.nersc",

--- a/src/decisionengine_modules/tests/test_NerscInstancePerformance.py
+++ b/src/decisionengine_modules/tests/test_NerscInstancePerformance.py
@@ -9,6 +9,7 @@ DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 CSV_FILE = os.path.join(DATA_DIR, "instance_performance_nersc.csv")
 
 CONFIG = {
+    "channel_name": "test",
     "csv_file": CSV_FILE,
 }
 

--- a/src/decisionengine_modules/tests/test_NerscJobInfo.py
+++ b/src/decisionengine_modules/tests/test_NerscJobInfo.py
@@ -13,6 +13,7 @@ TEST_FIXTURE_FILE = os.path.join(DATA_DIR, "newt_jobs.cs.test.fixture")
 PASSWD_FILE = os.path.join(DATA_DIR, "passwd")
 
 CONFIG = {
+    "channel_name": "test",
     "passwd_file": PASSWD_FILE,
     "constraints": {
         "machines": ["edison", "cori"],

--- a/src/decisionengine_modules/tests/test_factory_client.py
+++ b/src/decisionengine_modules/tests/test_factory_client.py
@@ -12,11 +12,13 @@ DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 FIXTURE_FILE = os.path.join(DATA_DIR, "factory_client.cs.fixture")
 
 CONFIG = {
+    'channel_name': "test",
     'condor_config': 'condor_config',
     'collector_host': 'cmssrv280.fnal.gov',
 }
 
 CONFIG_BAD = {
+    'channel_name': "test",
     'condor_config': 'condor_config',
     'collector_host': 'dummy_collector.fnal.gov',
 }

--- a/src/decisionengine_modules/tests/test_factory_entries.py
+++ b/src/decisionengine_modules/tests/test_factory_entries.py
@@ -15,6 +15,7 @@ DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 FIXTURE_FILE = os.path.join(DATA_DIR, "factory_entries.cs.fixture")
 
 CONFIG_FACTORY_ENTRIES = {
+    'channel_name': "test",
     'condor_config': 'condor_config',
     'factories': [
         {
@@ -24,6 +25,7 @@ CONFIG_FACTORY_ENTRIES = {
 }
 
 CONFIG_FACTORY_ENTRIES_BAD = {
+    'channel_name': "test",
     'condor_config': 'condor_config',
     'factories': [
         {
@@ -33,6 +35,7 @@ CONFIG_FACTORY_ENTRIES_BAD = {
 }
 
 CONFIG_FACTORY_ENTRIES_BAD_WITH_TIMEOUT = {
+    'channel_name': "test",
     'condor_config': 'condor_config',
     'nretries': 2,
     'retry_interval': 2,
@@ -44,6 +47,7 @@ CONFIG_FACTORY_ENTRIES_BAD_WITH_TIMEOUT = {
 }
 
 CONFIG_FACTORY_ENTRIES_CORMAP = {
+    "channel_name": "test",
     "condor_config": "/etc/condor/condor_config",
     "factories": [
         {

--- a/src/decisionengine_modules/tests/test_factory_global.py
+++ b/src/decisionengine_modules/tests/test_factory_global.py
@@ -13,6 +13,7 @@ DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 FIXTURE_FILE = os.path.join(DATA_DIR, "factory_global.cs.fixture")
 
 CONFIG = {
+    'channel_name': "test",
     'condor_config': 'condor_config',
     'factories': [
         {
@@ -22,6 +23,7 @@ CONFIG = {
 }
 
 CONFIG_BAD = {
+    'channel_name': "test",
     'condor_config': 'condor_config',
     'factories': [
         {
@@ -31,6 +33,7 @@ CONFIG_BAD = {
 }
 
 CONFIG_BAD_WITH_TIMEOUT = {
+    'channel_name': "test",
     'condor_config': 'condor_config',
     'nretries': 2,
     'retry_interval': 2,

--- a/src/decisionengine_modules/tests/test_grid_figure_of_merit.py
+++ b/src/decisionengine_modules/tests/test_grid_figure_of_merit.py
@@ -32,5 +32,5 @@ class TestGridFigureOfMerit():
             'EntryName': ['g1', 'g2', 'g3', 'g4', 'g5'],
             'Grid_Figure_Of_Merit': [sys.float_info.max, sys.float_info.max, sys.float_info.max, 1.050000e-02, 4.020000e-01]
         })
-        fom = GridFigureOfMerit({})
+        fom = GridFigureOfMerit({"channel_name": "test"})
         assert(test_df.equals(fom.transform(datablock).get('Grid_Figure_Of_Merit')))

--- a/src/decisionengine_modules/tests/test_job_clustering.py
+++ b/src/decisionengine_modules/tests/test_job_clustering.py
@@ -5,6 +5,7 @@ import pandas
 from decisionengine_modules.glideinwms.transforms import job_clustering
 
 config_test_match_exprs = {
+    "channel_name": "test",
     "match_expressions": [
         {
             "job_bucket_criteria_expr": "VO_Name=='cms' and RequestCpus==1 and (MaxWallTimeMins>0 and MaxWallTimeMins<= 60*12)",

--- a/src/decisionengine_modules/tests/test_job_clustering_publisher.py
+++ b/src/decisionengine_modules/tests/test_job_clustering_publisher.py
@@ -2,7 +2,8 @@ import pandas
 
 from decisionengine_modules.glideinwms.publishers import job_clustering_publisher
 
-config_pub = {"publish_to_graphite": True,
+config_pub = {"channel_name": "test",
+              "publish_to_graphite": True,
               "graphite_host": "lsdataitb.fnal.gov",
               "graphite_port": 2004,
               "graphite_context": "hepcloud.de.glideinwms",

--- a/src/decisionengine_modules/tests/test_job_q.py
+++ b/src/decisionengine_modules/tests/test_job_q.py
@@ -12,6 +12,7 @@ DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 FIXTURE_FILE = os.path.join(DATA_DIR, "cq.fixture")
 
 CONFIG_CQ = {
+    "channel_name": "test",
     "condor_config": "condor_config",
     "collector_host": "fermicloud122.fnal.gov",
     "schedds": ["fermicloud122.fnal.gov"],

--- a/src/decisionengine_modules/tests/test_slots.py
+++ b/src/decisionengine_modules/tests/test_slots.py
@@ -12,6 +12,7 @@ DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 FIXTURE_FILE = os.path.join(DATA_DIR, "cs.fixture")
 
 CONFIG = {
+    'channel_name': "test",
     'condor_config': 'condor_config',
     'collector_host': 'fermicloud122.fnal.gov',
 }

--- a/src/decisionengine_modules/util/figure_of_merit.py
+++ b/src/decisionengine_modules/util/figure_of_merit.py
@@ -4,6 +4,7 @@ Calculate figure of merit
 
 import sys
 import structlog
+from decisionengine.framework.modules.logging_configDict import CHANNELLOGGERNAME
 
 _INFINITY = sys.float_info.max
 
@@ -13,7 +14,8 @@ def figure_of_merit(performance,
                     allowed,
                     idle=None,
                     max_idle=None):
-    logger = structlog.getLogger()
+    logger = structlog.getLogger(CHANNELLOGGERNAME)
+    logger = logger.bind(module=__name__.split(".")[-1], channel="")
     try:
         if running >= allowed or allowed == 0:
             return _INFINITY

--- a/src/decisionengine_modules/util/retry_function.py
+++ b/src/decisionengine_modules/util/retry_function.py
@@ -3,6 +3,8 @@ from functools import wraps
 import structlog
 import time
 
+from decisionengine.framework.modules.logging_configDict import CHANNELLOGGERNAME
+
 def retry_on_error(nretries=1, retry_interval=2, backoff=True):
     def decorator(f):
         @wraps(f)
@@ -21,7 +23,8 @@ def retry_wrapper(f, nretries=1, retry_interval=2, backoff=True):
     Otherwise, use the default values or pass new values to the decorator.
     '''
     time2sleep = retry_interval
-    logger = structlog.getLogger()
+    logger = structlog.getLogger(CHANNELLOGGERNAME)
+    logger = logger.bind(module=__name__.split(".")[-1], channel="")
     for i in range(nretries + 1):
         try:
             return f()


### PR DESCRIPTION
Any classes that inherit from Source, SourceProxy, Transform, or Publisher will inherit the logger called "channelog" which corresponds to the appropriate channel the module is running in. Other modules and classes have the explicitly call the logger "channelog" by name using a structlog command.