### PR TITLE
Update release_notes_1.7.rst

### DIFF
--- a/doc/source/release_notes/release_notes_1.7.rst
+++ b/doc/source/release_notes/release_notes_1.7.rst
@@ -11,6 +11,8 @@ This release features:
 .. note::
     The RPM package was renamed from decisionengine-standard-library to decisionengine_modules. rpm/yum updates from the old RPM will work correctly.
 
+.. note::
+    The "channel_name" key in the Source Proxy config dictionaries needs to be changed to "source_channel". "channel_name" is now being used to describe the name of the channel itself, not the name of the channel the Source Proxy is gettting information from.
 
 Issues fixed in this release
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
added information about the change of "channel_name" in the Source Proxy configuration to "source_channel".