### PR TITLE
added new dummy source file

### DIFF
--- a/src/decisionengine_modules/glideinwms/sources/DummyFOMSource.py
+++ b/src/decisionengine_modules/glideinwms/sources/DummyFOMSource.py
@@ -1,0 +1,31 @@
+"""
+This dummy source takes the name of an FOM source datablock from config file
+as parameter "datablock_type" and produces an empty FOM datablock with that name
+"""
+import pandas as pd
+
+from decisionengine.framework.modules import Source
+from decisionengine.framework.modules.Source import Parameter
+
+
+@Source.supports_config(
+    Parameter("datablock_type", default=""),
+)
+class DummyFOMSource(Source.Source):
+    def __init__(self, config):
+        super().__init__(config)
+        self.logger = self.logger.bind(
+            class_module=__name__.split(".")[-1],
+        )
+        self.datablock_type = config.get("datablock_type")
+        if not self.datablock_type:
+            raise RuntimeError("No datablock_type found in configuration")
+
+        self._produces = {self.datablock_type: pd.DataFrame}
+
+    def acquire(self):
+        self.logger.debug(f"in DummyFOMSource: {self.datablock_type} acquire")
+        return {self.datablock_type: pd.DataFrame()}
+
+
+Source.describe(DummyFOMSource)


### PR DESCRIPTION
I have added a new module that creates an empty Figure_of_Merit datablock to address Issue #350 https://github.com/HEPCloud/decisionengine_modules/issues/350. The module takes in a single parameter "datablock_type" from the config file as shown here:
```
    "dummy_nersc_fom_source": {
      "module": "decisionengine_modules.glideinwms.sources.DummyFOMSource",
      "name": "DummyFOMSource",
      "parameters": {
        "datablock_type": "Nersc_Figure_Of_Merit",
      }
    },
```
I have tested the module by running a set of config files that Steve gave to me, and there were no errors related to the necessary datablocks.