### PR TITLE
Change GlideinWMS module to read configuration from the DE framework

### DIFF
--- a/src/decisionengine_modules/glideinwms/ConfigSource.py
+++ b/src/decisionengine_modules/glideinwms/ConfigSource.py
@@ -1,0 +1,24 @@
+import abc
+
+from glideinwms.lib.xmlParse import OrderedDict
+
+
+class ConfigSource(OrderedDict, metaclass=abc.ABCMeta):
+    """Abstract class representing a configuration parser"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.update(self.load_config())
+
+    @abc.abstractmethod
+    def load_config(self) -> OrderedDict:
+        """
+        Reads the configuration source and returns a dictionary
+        """
+        raise NotImplementedError
+
+
+class ConfigError(Exception):
+    """Exception raised when the configuration source is invalid"""
+
+    pass

--- a/src/decisionengine_modules/glideinwms/DEConfigSource.py
+++ b/src/decisionengine_modules/glideinwms/DEConfigSource.py
@@ -1,0 +1,25 @@
+import json
+
+from glideinwms.lib.xmlParse import OrderedDict
+
+from decisionengine.framework.engine import de_client
+from decisionengine_modules.glideinwms.ConfigSource import ConfigError, ConfigSource
+
+
+class DEConfigSource(ConfigSource):
+    """
+    Handles HEPCloud Decision Engine configuration source.
+    """
+
+    def __init__(self, host="localhost", port="8888"):
+        self.host = host
+        self.port = port
+        super().__init__()
+
+    def load_config(self):
+        try:
+            de_config = de_client.main(["--port", self.port, "--host", self.host, "--show-de-config"])
+            de_config = json.loads(de_config, object_hook=OrderedDict)["glideinwms"]
+            return de_config
+        except Exception as e:
+            raise ConfigError(f"Failed to load HEPCloud Decision Engine configuration: {e}")

--- a/src/decisionengine_modules/glideinwms/UniversalFrontendParams.py
+++ b/src/decisionengine_modules/glideinwms/UniversalFrontendParams.py
@@ -1,0 +1,41 @@
+import copy
+
+from glideinwms.creation.lib.cvWParams import VOFrontendParams
+
+
+class UniversalFrontendParams(VOFrontendParams):
+    """
+    Implements VOFrontendParams with a universal config parser.
+
+    This class overrides the constructor of the Params class to support different configuration formats.
+    TODO: This class should be removed when these changes are implemented in the Params class itself.
+    """
+
+    def __init__(self, src_dir, config_source):
+        """Constructor. Load the default values and override with the configuration content.
+
+        Args:
+            src_dir (str): frontend source directory
+            config_parser (ConfigSource): configuration source
+        """
+
+        self.src_dir = src_dir
+
+        # initialize the defaults
+        self.defaults = {}
+        self.init_defaults()
+
+        try:
+            self.data = config_source
+            self.subparams = self.get_subparams_class()(self.data)
+            self.subparams.validate(self.defaults, self.get_top_element())
+
+            # make a copy of the loaded data, so that I can always tell what was derived and what was not
+            self.org_data = copy.deepcopy(self.data)
+
+            self.subparams.use_defaults(self.defaults)
+
+            # create derived values
+            self.derive()
+        except RuntimeError as e:
+            raise RuntimeError("Unexpected error while loading the config file: %s" % e)

--- a/src/decisionengine_modules/glideinwms/configure_gwms_frontend.py
+++ b/src/decisionengine_modules/glideinwms/configure_gwms_frontend.py
@@ -2,7 +2,6 @@ import argparse
 import os
 import os.path
 import sys
-import tempfile
 
 import glideinwms.creation.lib.cvWConsts
 import glideinwms.creation.lib.cvWDictFile
@@ -12,18 +11,14 @@ import glideinwms.creation.lib.cWConsts
 import glideinwms.creation.lib.xslt
 
 from decisionengine_modules.glideinwms import glideinwms_config_lib
-
-
-def frontend_to_de_config(frontend_workdir="/var/lib/gwms-frontend/vofrontend"):
-    fe_configuration = glideinwms_config_lib.FrontendConfiguration(frontend_workdir=frontend_workdir)
-    return fe_configuration.frontend_config
+from decisionengine_modules.glideinwms.DEConfigSource import DEConfigSource
+from decisionengine_modules.glideinwms.UniversalFrontendParams import UniversalFrontendParams
 
 
 def main(args):
-
-    # Load params from frontend configuration file
-    print(f"...Loading frontend configuration from {args.frontend_config} ...")
-    params = load_params_from_config(args, usage=usage)
+    # Load params from the decision engine configuration
+    print("...Loading GlideinWMS module configuration from the decision engine ...")
+    params = UniversalFrontendParams(args.web_base_dir, DEConfigSource())
 
     # Create dictionaries for new params
     frontend_dicts_obj = glideinwms.creation.lib.cvWParamDict.frontendDicts(params)
@@ -33,29 +28,9 @@ def main(args):
         # Update scripts will always be true.
         frontend_dicts_obj.create_dirs(fail_if_exists=False)
 
-    # load old files and merge them together
-    # if old_params is not None:
-    #    old_frontend_dicts_obj = cvWParamDict.frontendDicts(old_params)
-    #    old_frontend_dicts_obj.load()
-    #    frontend_dicts_obj.reuse(old_frontend_dicts_obj)
-
     # Write contents to disk
     frontend_dicts_obj.save()
     frontend_dicts_obj.set_readonly(True)
-    cfgfile = os.path.join(frontend_dicts_obj.main_dicts.work_dir, glideinwms.creation.lib.cvWConsts.XML_CONFIG_FILE)
-
-    # save config into file (with backup, since the old one already exists)
-    # This is the current working version of the frontend in the
-    # frontend instance dir
-    params.save_into_file_wbackup(cfgfile, set_ro=True)
-    print("...Saved the current config file into the working dir")
-
-    # make backup copy that does not get overwritten on further reconfig
-    # This file is has a hash on the extension and is located in the
-    # frontend instance dir
-    cfgfile = glideinwms.creation.lib.cWConsts.insert_timestr(cfgfile)
-    params.save_into_file(cfgfile, set_ro=True)
-    print("...Saved the backup config file into the working dir")
 
     fe_configuration = glideinwms_config_lib.FrontendConfiguration()
     fe_configuration.save(args.de_frontend_config, set_ro=True)
@@ -79,13 +54,6 @@ def get_arg_parser():
 
     parser = argparse.ArgumentParser(description=description, formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument(
-        "--frontend-config",
-        action="store",
-        dest="frontend_config",
-        default="/etc/gwms-frontend/frontend.xml",
-        help="Full path to the GlideinWMS frontend configuration file",
-    )
-    parser.add_argument(
         "--de-frontend-config",
         action="store",
         dest="de_frontend_config",
@@ -94,13 +62,6 @@ def get_arg_parser():
     )
     parser.add_argument(
         "--update-scripts", action="store_true", dest="update_scripts", help="Update the scripts in the working area"
-    )
-    parser.add_argument(
-        "--xslt-plugin-dir",
-        action="store",
-        dest="xslt_plugin_dir",
-        default=None,
-        help="Location of the xslt plugin directory. NOT SUPPORTED.",
     )
     parser.add_argument(
         "--web-base-dir",
@@ -113,51 +74,11 @@ def get_arg_parser():
     return parser
 
 
-def load_params_from_config(args, usage=""):
-    try:
-        transformed_xmlfile = tempfile.NamedTemporaryFile()
-        transformed_xmlfile.write(
-            glideinwms.creation.lib.xslt.xslt_xml(
-                old_xmlfile=args.frontend_config, xslt_plugin_dir=args.xslt_plugin_dir
-            )
-        )
-        transformed_xmlfile.flush()
-    except RuntimeError as e:
-        print(e)
-        sys.exit(1)
-
-    params = glideinwms.creation.lib.cvWParams.VOFrontendParams(
-        usage, args.web_base_dir, [sys.argv[0], transformed_xmlfile.name]
-    )
-    params.cfg_name = args.frontend_config
-    return params
-
-
-def get_old_params(params, args):
-    # This is the current running version, saved in the frontend work dir
-    old_config_file = os.path.join(params.work_dir, glideinwms.creation.lib.cvWConsts.XML_CONFIG_FILE)
-    # print old_config_file
-    if os.path.exists(old_config_file):
-        try:
-            old_params = glideinwms.creation.lib.cvWParams.VOFrontendParams(
-                args.usage, args.web_base_dir, [sys.argv[0], old_config_file]
-            )
-        except RuntimeError:
-            raise RuntimeError(f"Failed to load {old_config_file}")
-    else:
-        print(f"Warning: Cannot find {old_config_file}")
-        print("Ignore above warning if this is the first reconfig")
-        old_params = None
-
-    return old_params
-
-
 ############################################################
 #
 # S T A R T U P
 #
 ############################################################
-
 
 if __name__ == "__main__":
 
@@ -168,11 +89,10 @@ if __name__ == "__main__":
 
     parser = get_arg_parser()
     args = parser.parse_args()
-    usage = parser.format_usage()
 
     try:
         main(args)
     except RuntimeError as e:
-        print(f"\nError processing the configuration {args.frontend_config}:")
+        print("\nError processing the configuration")
         print(e)
         sys.exit(1)

--- a/src/decisionengine_modules/glideinwms/tests/fixtures.py
+++ b/src/decisionengine_modules/glideinwms/tests/fixtures.py
@@ -1,0 +1,62 @@
+import json
+
+from unittest import mock
+
+import pytest
+
+from glideinwms.lib.xmlParse import OrderedDict
+
+
+@pytest.fixture(scope="module")
+def gwms_src_dir():
+    return "/tmp/gwms_mock_dir"
+
+
+@pytest.fixture(scope="module")
+def gwms_module_config():
+    MODULE_CONFIG = """{
+        "frontend_name": "mock_frontend",
+        "groups": {
+            "main": {}
+        },
+        "security": {
+            "proxy_DN": "/DC=org/DC=incommon/C=US/ST=Illinois/L=Batavia/O=Fermi Research Alliance/OU=Fermilab/CN=mock_frontend.fnal.gov"
+        },
+        "collectors": [
+            {
+                "DN": "/DC=org/DC=incommon/C=US/ST=Illinois/L=Batavia/O=Fermi Research Alliance/OU=Fermilab/CN=mock_collector.fnal.gov",
+                "group": "default",
+                "node": "mock_collector.fnal.gov:9618",
+                "secondary": "False"
+            }
+        ]
+    }"""
+
+    return json.loads(MODULE_CONFIG, object_hook=OrderedDict)
+
+
+@pytest.fixture(scope="module")
+def gwms_module_invalid_config():
+    MODULE_INVALID_CONFIG = """{
+        "frontend_name": "mock_frontend",
+        "invalid_key": "test_value"
+    }"""
+
+    return json.loads(MODULE_INVALID_CONFIG, object_hook=OrderedDict)
+
+
+@pytest.fixture(scope="module")
+def de_client_config():
+    GWMS_MOCK_CONFIG = """{
+        "glideinwms": {
+            "value": "foo",
+            "list": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+            "dict": {
+                "a": 1,
+                "b": 2,
+                "c": 3
+            }
+        }
+    }"""
+
+    return mock.patch("decisionengine.framework.engine.de_client.main", return_value=GWMS_MOCK_CONFIG)

--- a/src/decisionengine_modules/glideinwms/tests/test_ConfigSource.py
+++ b/src/decisionengine_modules/glideinwms/tests/test_ConfigSource.py
@@ -1,0 +1,8 @@
+from decisionengine_modules.glideinwms.ConfigSource import ConfigSource
+
+
+def test_abstract_instantiation():
+    try:
+        ConfigSource()
+    except Exception as e:
+        assert isinstance(e, NotImplementedError)

--- a/src/decisionengine_modules/glideinwms/tests/test_DEConfigSource.py
+++ b/src/decisionengine_modules/glideinwms/tests/test_DEConfigSource.py
@@ -1,0 +1,16 @@
+from decisionengine_modules.glideinwms.ConfigSource import ConfigError
+from decisionengine_modules.glideinwms.DEConfigSource import DEConfigSource
+from decisionengine_modules.glideinwms.tests.fixtures import de_client_config  # noqa: F401
+
+
+def test_instantiation(de_client_config):  # noqa: F811
+    with de_client_config:
+        config = DEConfigSource()
+        assert config["value"] == "foo"
+
+
+def test_config_error():
+    try:
+        _ = DEConfigSource()
+    except Exception as e:
+        assert isinstance(e, ConfigError)

--- a/src/decisionengine_modules/glideinwms/tests/test_UniversalFrontendParams.py
+++ b/src/decisionengine_modules/glideinwms/tests/test_UniversalFrontendParams.py
@@ -1,0 +1,18 @@
+from decisionengine_modules.glideinwms.tests.fixtures import (  # noqa: F401
+    gwms_module_config,
+    gwms_module_invalid_config,
+    gwms_src_dir,
+)
+from decisionengine_modules.glideinwms.UniversalFrontendParams import UniversalFrontendParams
+
+
+def test_instantiation(gwms_src_dir, gwms_module_config):  # noqa: F811
+    params = UniversalFrontendParams(gwms_src_dir, gwms_module_config)
+    assert params.subparams["frontend_name"] == "mock_frontend"
+
+
+def test_config_error(gwms_src_dir, gwms_module_invalid_config):  # noqa: F811
+    try:
+        _ = UniversalFrontendParams(gwms_src_dir, gwms_module_invalid_config)
+    except Exception as e:
+        assert isinstance(e, RuntimeError)

--- a/src/decisionengine_modules/glideinwms/tests/test_configure_gwms_frontend.py
+++ b/src/decisionengine_modules/glideinwms/tests/test_configure_gwms_frontend.py
@@ -1,0 +1,18 @@
+from argparse import ArgumentParser
+
+from decisionengine_modules.glideinwms import configure_gwms_frontend
+from decisionengine_modules.glideinwms.tests.fixtures import de_client_config  # noqa: F401
+
+
+def test_get_arg_parser():
+    parser = configure_gwms_frontend.get_arg_parser()
+    assert isinstance(parser, ArgumentParser)
+
+
+# TODO: This test requires the new GlideinWMS RPMs to be installed.
+# def test_main():
+#     args = Namespace()
+#     args.web_base_dir = "/var/lib/gwms-frontend/web-base"
+#     args.update_scripts = False
+#     args.de_frontend_config = "/var/lib/gwms-frontend/vofrontend/de_frontend_config"
+#     configure_gwms_frontend.main(args)


### PR DESCRIPTION
This PR contains changes to the configure_gwms_frontend.py script to read configurations from the de-client instead of the frontend XML configuration file.

It also adds the following components:

- UniversalFrontendParams: A frontend interface that receives a generic configuration source.
- ConfigSource: An abstract class that defines a generic configuration source.
- DEConfigSource: An implementation of ConfigSource that sources information from the de-client.