### PR TITLE
Set fail-fast to false to allow py3.6 tests to complete

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,10 +13,11 @@ jobs:
   pytest:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - "3.6"
-          - "3.10"
+          - "3.9"
 
     name: Python ${{ matrix.python-version }} unit tests
     steps:


### PR DESCRIPTION
Set fail-fast to false to allow py3.6 tests to complete also when higher version fail. 
Temporarily downgraded from py3.10 to py3.9 because the condor dependency is not available yet for py3.10.