### PR TITLE
Rename consumed product so that translation is not necessary

### DIFF
--- a/src/decisionengine_modules/AWS/tests/test_FigureOfMerit.py
+++ b/src/decisionengine_modules/AWS/tests/test_FigureOfMerit.py
@@ -16,7 +16,7 @@ expected_reply = {
     "AWS_Price_Performance": pd.read_csv(os.path.join(DATA_DIR, "expected_price_performance.csv")),
 }
 consumes = dict.fromkeys(
-    ["provisioner_resource_spot_prices", "Performance_Data", "Job_Limits", "AWS_Occupancy"], pd.DataFrame
+    ["provisioner_resource_spot_prices", "Performance_Data", "aws_instance_limits", "AWS_Occupancy"], pd.DataFrame
 )
 
 produces = dict.fromkeys(["AWS_Price_Performance", "AWS_Figure_Of_Merit"], pd.DataFrame)
@@ -32,7 +32,7 @@ def create_datablock():
         .drop_duplicates(subset=["AvailabilityZone", "InstanceType"], keep="last")
         .reset_index(drop=True)
     )
-    data_block["Job_Limits"] = (
+    data_block["aws_instance_limits"] = (
         pd.read_csv(os.path.join(DATA_DIR, "job_limits.csv"))
         .drop_duplicates(subset=["AvailabilityZone", "InstanceType"], keep="last")
         .reset_index(drop=True)

--- a/src/decisionengine_modules/AWS/transforms/FigureOfMerit.py
+++ b/src/decisionengine_modules/AWS/transforms/FigureOfMerit.py
@@ -38,7 +38,7 @@ def figure_of_merit(RunningVms, MaxLimit, PricePerf):
 @Transform.consumes(
     provisioner_resource_spot_prices=pd.DataFrame,
     Performance_Data=pd.DataFrame,
-    Job_Limits=pd.DataFrame,
+    aws_instance_limits=pd.DataFrame,
     AWS_Occupancy=pd.DataFrame,
 )
 @Transform.produces(AWS_Price_Performance=pd.DataFrame, AWS_Figure_Of_Merit=pd.DataFrame)
@@ -59,7 +59,7 @@ class FigureOfMerit(Transform.Transform):
         spot_price_data = self.provisioner_resource_spot_prices(data_block)
         perf_data = self.Performance_Data(data_block)
         occup_data = self.AWS_Occupancy(data_block)
-        job_limits_data = self.Job_Limits(data_block)
+        job_limits_data = self.aws_instance_limits(data_block)
 
         price_perf_rows = []
         fom_rows = []


### PR DESCRIPTION
This is a necessary ingredient in removing the source proxy, which uses the product-name translation:
```
"aws_instance_limits -> Job_Limits"
```