### PR TITLE
pin pytest version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ runtime_require = [
 
 # pull in development requirements
 devel_req = [
-    "pytest >= 6.2.2",
+    "pytest >= 6.2.2, < 7.0",  # pytest 7 incompatible with pytest-postgres < 4 from DE
     "pytest-cov >= 2.11.1",
     "pytest-flake8 >= 1.0.7",
     "tabulate >= 0.8.8",


### PR DESCRIPTION
This makes the pair with [DE PR#609](https://github.com/HEPCloud/decisionengine/pull/609) from @jcpunk
CI test of DE modules on Jenkins are [failing](https://buildmaster.fnal.gov/buildmaster/view/Decision%20Engine/job/decisionengine_modules_pipeline/1793/execution/node/88/log/)