### PR TITLE
Fix GlideClientGlobal create_invalidate_constraint

### DIFF
--- a/src/decisionengine_modules/glideinwms/publishers/glideclientglobal.py
+++ b/src/decisionengine_modules/glideinwms/publishers/glideclientglobal.py
@@ -13,12 +13,13 @@ class GlideClientGlobalManifests(publisher.HTCondorManifests):
 
     def create_invalidate_constraint(self, dataframe):
         self.logger.debug("in GlideClientGlobalManifests create_invalidate_constraint")
-        for collector_host, group in dataframe.groupby(["CollectorHost"]):
-            client_names = list(set(group["ClientName"]))
-            client_names.sort()
-            if client_names:
-                constraint = f"""(glideinmytype == "{self.classad_type}") && (stringlistmember(ClientName, "{','.join(client_names)}"))"""
-                self.invalidate_ads_constraint[collector_host] = constraint
+        if not dataframe.empty:
+            for collector_host, group in dataframe.groupby(["CollectorHost"]):
+                client_names = list(set(group["ClientName"]))
+                client_names.sort()
+                if client_names:
+                    constraint = f"""(glideinmytype == "{self.classad_type}") && (stringlistmember(ClientName, "{','.join(client_names)}"))"""
+                    self.invalidate_ads_constraint[collector_host] = constraint
 
 
 Publisher.describe(GlideClientGlobalManifests)


### PR DESCRIPTION
This PR fixes an issue with the GlideinWMS `glideclientglobal` module, which would cause it to crash when calling the `create_invalidate_constraint` function for an empty dataframe.