### PR TITLE
Port PR402 to 1.7 branch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,8 @@ runtime_require = [
 
 # pull in development requirements
 devel_req = [
-    "pytest >= 6.2.2", "pytest-cov >= 2.11.1", "pytest-flake8 >= 1.0.7",
+    "pytest >= 6.2.2, < 7.0",  # pytest 7 incompatible with pytest-postgres < 4
+    "pytest-cov >= 2.11.1", "pytest-flake8 >= 1.0.7",
     "tabulate >= 0.8.8", "toml >= 0.10.2", "pyyaml >= 5.4.1",
     "sphinx >= 3.5.3", "sphinx_rtd_theme >= 0.5.1",
     "packaging >= 20.9", "wheel >= 0.36.2",


### PR DESCRIPTION
This is an update for setup.py to pin pytest version to v6 series.
This is required to all CI test for 1.7 branch of DE modules to run on Jenkins. Currently we have this [failure](https://buildmaster.fnal.gov/buildmaster/view/Decision%20Engine/job/decisionengine_modules_pipeline/1820/execution/node/52/log/) due to pytest v7.0.1.