### PR TITLE
Update rpm-build workflow

### DIFF
--- a/.github/workflows/rpm-build.yaml
+++ b/.github/workflows/rpm-build.yaml
@@ -4,17 +4,40 @@
 ---
 name: Build DecisionEngine Modules RPM
 
-on: [pull_request, push]
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "branch ref"
+        required: true
+        default: "master"
 
 jobs:
   rpmbuild_el7:
     name: Build an EL7 rpm
     runs-on: ubuntu-latest
     steps:
+      - name: make date tag
+        id: mkdatetag
+        run: echo "::set-output name=dtag::$(date +%Y%m%d_%H%M%S)"
+
+      - name: make ref tag case 1
+        id: mkreftag1
+        if: ${{ github.event.inputs.ref != '' }}
+        run: echo "::set-output name=reftag::${{github.event.inputs.ref}}"
+
+      - name: make ref tag case 2
+        id: mkreftag2
+        if: ${{ github.event.inputs.ref == '' }}
+        run: echo "::set-output name=reftag::${GITHUB_BASE_REF:+PR}"$(awk -F"/" '{print $3}' <<< ${GITHUB_REF})
+
       - name: Checkout code tree
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          ref: ${{github.event.inputs.ref}}
 
       - name: Run the build in a container (SL7/HEPCloud-CI)
         uses: ./.github/actions/python-command-in-sl7-container
@@ -25,6 +48,6 @@ jobs:
       - name: Archive rpm
         uses: actions/upload-artifact@v2
         with:
-          name: rpms
+          name: rpms-DEM-${{steps.mkreftag1.outputs.reftag}}${{steps.mkreftag2.outputs.reftag}}-${{steps.mkdatetag.outputs.dtag}}
           path: dist/*.rpm
           if-no-files-found: error


### PR DESCRIPTION
The rpm-build workflow has been updated to include the workflow_dispatch action mechanism.
This allows to trigger this action through an API or directly through the action dashboard,
This PR also customize the RPM artifact file name.