### PR TITLE
Extend FE group classads publisher to allow configurable queries

### DIFF
--- a/src/decisionengine_modules/glideinwms/publishers/fe_group_classads.py
+++ b/src/decisionengine_modules/glideinwms/publishers/fe_group_classads.py
@@ -8,78 +8,59 @@ from decisionengine_modules.htcondor.publishers import publisher
 
 # FIXME: Awkward entanglements between subclass and base class.
 
-# TODO: Enable publishing of glideresource_manifests
-#'glideclient_manifests', 'glideresource_manifests',
-_CONSUMES = [
-    "glideclient_manifests",
-    "Factory_Entries_Grid",
-    "Factory_Entries_AWS",
-    "Factory_Entries_GCE",
-    "Factory_Entries_LCF",
-]
-_CONSUMES_DICT = dict.fromkeys(_CONSUMES, pandas.DataFrame)
 
-
-@Publisher.consumes(**_CONSUMES_DICT)
 class GlideinWMSManifests(publisher.HTCondorManifests):
     def __init__(self, config):
         super().__init__(config)
-        self._fact_entrytype_map = {
-            "allow_grid_requests": "Factory_Entries_Grid",
-            "allow_aws_requests": "Factory_Entries_AWS",
-            "allow_gce_requests": "Factory_Entries_GCE",
-            "allow_lcf_requests": "Factory_Entries_LCF",
-        }
+        self.allow_types = ["Grid", "AWS", "GCE", "LCF"]
+        self._consumes = {f"Factory_Entries_{key}": pandas.DataFrame for key in self.allow_types}
+        self._consumes.update(glideclient_manifests=pandas.DataFrame)
         self.classad_type = "glideclient"
 
     def publish(self, datablock):
         self.logger.debug("in GlideinWMSManifests publish")
-        requests_df = datablock.get("glideclient_manifests")
+
         facts_df = datablock.get("de_logicengine_facts")
-
-        # Create a map of allow facts & entries
-        allow_type_entries = {i: datablock.get(self._fact_entrytype_map[i]) for i in self._fact_entrytype_map}
-
-        # Initialize to empty dataframes and add row at a time
-        allow_type_req_dfs = {i: pandas.DataFrame() for i in self._fact_entrytype_map}
-        for _index, row in requests_df.iterrows():
-            # Iterate through all requests one at a time
-            # Check if the ReqName coincides with the allowed request types
-            req_name = row["ReqName"]
-
-            # Identify the type of request ie (grid|gce|aws|lcf))
-            for allow_type in allow_type_entries:
-                these_entries = allow_type_entries[allow_type]
-                if len(these_entries.query(f'Name=="{req_name}"')) > 0:
-                    # This request belongs to allowed_type
-                    allow_type_req_dfs[allow_type] = allow_type_req_dfs[allow_type].append(row)
-                    break
-
         self.logger.info(
             f"Facts available in publisher {self.__class__.__name__}: {facts_df.to_dict(orient='records')}"
         )
-        for _index, row in facts_df.iterrows():
-            fact_name = row["fact_name"]
-            fact_value = f"{row['fact_value']}".lower() == "true"
-            if not fact_value:
-                # Convert request idle to 0
-                # TODO: Check what to do with max running
-                #       For now keep it same so existing glideins can finish
-                self.logger.info(f"Setting ReqIdleGlideins=0 for fact: {fact_name}")
-                allow_type_req_dfs[fact_name]["ReqIdleGlideins"] = [0] * len(allow_type_req_dfs[fact_name])
 
-        publish_requests_df = pandas.DataFrame(pandas.concat(allow_type_req_dfs.values(), ignore_index=True, sort=True))
+        publish_requests_df = pandas.DataFrame()
+        for allow_type in self.allow_types:
+            df = self.dataframe_for_entrytype(allow_type, datablock)
+            publish_requests_df = pandas.concat([publish_requests_df, df], ignore_index=True, sort=True)
+
         self.publish_to_htcondor(self.classad_type, publish_requests_df)
         self.create_invalidate_constraint(publish_requests_df)
 
     def create_invalidate_constraint(self, requests_df):
-        if not requests_df.empty:
-            for collector_host, request_group in requests_df.groupby(["CollectorHost"]):
-                client_names = list(set(request_group["ClientName"]))
-                client_names.sort()
-                if client_names:
-                    constraint = f"""(glideinmytype == "{self.classad_type}") && (stringlistmember(ClientName, "{','.join(client_names)}"))"""
-                    self.invalidate_ads_constraint[collector_host] = constraint
+        if requests_df.empty:
+            return
+
+        for collector_host, request_group in requests_df.groupby(["CollectorHost"]):
+            client_names = list(set(request_group["ClientName"]))
+            client_names.sort()
+            if client_names:
+                constraint = f"""(glideinmytype == "{self.classad_type}") && (stringlistmember(ClientName, "{','.join(client_names)}"))"""
+                self.invalidate_ads_constraint[collector_host] = constraint
+
+    def dataframe_for_entrytype(self, allow_type, datablock):
+        requests_df = datablock.get("glideclient_manifests")
+        facts_df = datablock.get("de_logicengine_facts")
+
+        data_product_name = f"Factory_Entries_{allow_type}"
+        fact_name = f"allow_{allow_type.lower()}_requests"
+        entries = datablock.get(data_product_name)
+        # Find the overlap between requests_df and the entries df, using a join-type method.
+        df = requests_df.merge(entries.Name, left_on="ReqName", right_on="Name").drop(columns=["Name"])
+        not_allowed = facts_df.query(f"fact_name == '{fact_name}' and fact_value == True").empty
+        if not_allowed:
+            # Convert request idle to 0
+            # TODO: Check what to do with max running
+            #       For now keep it same so existing glideins can finish
+            self.logger.info(f"Setting ReqIdleGlideins=0 for fact: {allow_type}")
+            df["ReqIdleGlideins"] = 0
+        return df
 
 
 Publisher.describe(GlideinWMSManifests)

--- a/src/decisionengine_modules/glideinwms/publishers/fe_group_classads.py
+++ b/src/decisionengine_modules/glideinwms/publishers/fe_group_classads.py
@@ -4,6 +4,7 @@
 import pandas
 
 from decisionengine.framework.modules import Publisher
+from decisionengine_modules.glideinwms.sources.factory_entries import ENTRY_TYPES
 from decisionengine_modules.htcondor.publishers import publisher
 
 # FIXME: Awkward entanglements between subclass and base class.
@@ -16,9 +17,8 @@ def split_dataframe(df, at):
 class GlideinWMSManifests(publisher.HTCondorManifests):
     def __init__(self, config):
         super().__init__(config)
-        self.allow_types = ["Grid", "AWS", "GCE", "LCF"]
         self.queries = config.get("queries", {})
-        self._consumes = {f"Factory_Entries_{key}": pandas.DataFrame for key in self.allow_types}
+        self._consumes = {f"Factory_Entries_{key}": pandas.DataFrame for key in ENTRY_TYPES.keys()}
         self._consumes.update(glideclient_manifests=pandas.DataFrame)
         self.classad_type = "glideclient"
 
@@ -31,7 +31,7 @@ class GlideinWMSManifests(publisher.HTCondorManifests):
         )
 
         publish_requests_df = pandas.DataFrame()
-        for allow_type in self.allow_types:
+        for allow_type in ENTRY_TYPES.keys():
             df = self.dataframe_for_entrytype(allow_type, datablock)
             publish_requests_df = pandas.concat([publish_requests_df, df], ignore_index=True, sort=True)
 

--- a/src/decisionengine_modules/glideinwms/sources/factory_entries.py
+++ b/src/decisionengine_modules/glideinwms/sources/factory_entries.py
@@ -10,6 +10,13 @@ from decisionengine.framework.modules.Source import Parameter
 from decisionengine_modules.htcondor import htcondor_query
 from decisionengine_modules.util.retry_function import retry_wrapper
 
+ENTRY_TYPES = {
+    "Grid": ["gt2", "condor"],
+    "AWS": ["ec2"],
+    "GCE": ["gce"],
+    "LCF": ["batch slurm"],
+}
+
 
 @Source.supports_config(
     Parameter("condor_config", type=str, comment="path to condor configuration"),
@@ -39,12 +46,6 @@ class FactoryEntries(Source.Source):
         super().__init__(config)
         self.condor_config = config.get("condor_config")
         self.factories = config.get("factories", [])
-        self._entry_gridtype_map = {
-            "Grid": ["gt2", "condor"],
-            "AWS": ["ec2"],
-            "GCE": ["gce"],
-            "LCF": ["batch slurm"],
-        }
 
         # The combination of max_retries=10 and retry_interval=2 adds up to just
         # over 15 minutes
@@ -110,10 +111,10 @@ class FactoryEntries(Source.Source):
         if dataframe.empty:
             # There were no entry classads in the factory collector or
             # quering the collector failed
-            return {f"Factory_Entries_{key}": pandas.DataFrame() for key in self._entry_gridtype_map.keys()}
+            return {f"Factory_Entries_{key}": pandas.DataFrame() for key in ENTRY_TYPES.keys()}
 
         results = {}
-        for key, value in self._entry_gridtype_map.items():
+        for key, value in ENTRY_TYPES.items():
             results[f"Factory_Entries_{key}"] = dataframe.loc[dataframe.GLIDEIN_GridType.isin(value)]
         return results
 

--- a/src/decisionengine_modules/htcondor/publishers/publisher.py
+++ b/src/decisionengine_modules/htcondor/publishers/publisher.py
@@ -143,17 +143,18 @@ class HTCondorManifests(Publisher.Publisher, metaclass=abc.ABCMeta):
         pass
 
     def publish_to_htcondor(self, key, dataframe):
+        if dataframe.empty:
+            self.logger.info(f"No {key} classads found to advertise")
+            return
+
         try:
             # TODO: How can we do this pandas way rather than interative?
-            if not dataframe.empty:
-                # Iterate over sub dataframes with same CollectorHost value
-                for collector in pandas.unique(dataframe.CollectorHost.ravel()):
-                    # Convert dataframe -> dict -> classads
-                    ads = dataframe_to_classads(dataframe[(dataframe["CollectorHost"] == collector)])
-                    # Advertise the classad to given collector
-                    self.condor_advertise(ads, collector_host=collector)
-            else:
-                self.logger.info(f"No {key} classads found to advertise")
+            # Iterate over sub dataframes with same CollectorHost value
+            for collector in pandas.unique(dataframe.CollectorHost.ravel()):
+                # Convert dataframe -> dict -> classads
+                ads = dataframe_to_classads(dataframe[(dataframe["CollectorHost"] == collector)])
+                # Advertise the classad to given collector
+                self.condor_advertise(ads, collector_host=collector)
         except Exception:
             self.logger.exception("Failed to publish")
 

--- a/src/decisionengine_modules/tests/test_factory_entries.py
+++ b/src/decisionengine_modules/tests/test_factory_entries.py
@@ -7,7 +7,6 @@ import time
 
 from unittest import mock
 
-import pandas
 import pandas as pd
 
 from decisionengine_modules.glideinwms.sources import factory_entries
@@ -64,10 +63,7 @@ CONFIG_FACTORY_ENTRIES_CORMAP = {
 
 def test_produces():
     entries = factory_entries.FactoryEntries(CONFIG_FACTORY_ENTRIES)
-    produces = dict.fromkeys(
-        ["Factory_Entries_Grid", "Factory_Entries_AWS", "Factory_Entries_GCE", "Factory_Entries_LCF"],
-        pandas.DataFrame,
-    )
+    produces = {f"Factory_Entries_{entrytype}": pd.DataFrame for entrytype in ["Grid", "AWS", "GCE", "LCF"]}
     assert entries._produces == produces
 
 
@@ -87,7 +83,7 @@ def test_acquire_bad():
     entries = factory_entries.FactoryEntries(CONFIG_FACTORY_ENTRIES_BAD)
     result = entries.acquire()
     for df in result.values():
-        assert df.dropna().empty is True
+        assert df.dropna().empty
 
 
 def test_acquire_bad_with_timeout():
@@ -98,14 +94,12 @@ def test_acquire_bad_with_timeout():
     # Set by tuning max_retries and the retry_interval
     assert end - start > 5
     for df in result.values():
-        assert df.dropna().empty is True
+        assert df.dropna().empty
 
 
 def test_acquire_correctionmap():
-    d1 = {"GLIDEIN_Resource_Slots": ["DummySlots", "DummySlots"]}
-    d2 = {"GLIDEIN_CMSSite": ["DummySite", "DummySite"]}
-    df1 = pd.DataFrame(data=d1)
-    df2 = pd.DataFrame(data=d2)
+    df1 = pd.DataFrame(data={"GLIDEIN_Resource_Slots": ["DummySlots", "DummySlots"]})
+    df2 = pd.DataFrame(data={"GLIDEIN_CMSSite": ["DummySite", "DummySite"]})
 
     entries = factory_entries.FactoryEntries(CONFIG_FACTORY_ENTRIES_CORMAP)
     with mock.patch.object(htcondor_query.CondorStatus, "fetch") as f:

--- a/src/decisionengine_modules/util/testutils.py
+++ b/src/decisionengine_modules/util/testutils.py
@@ -6,8 +6,6 @@
 """
 import datetime  # noqa: F401
 
-import pandas as pd  # noqa: F401
-
 # These imports needed for the `eval` blocks
 from classad import classad  # noqa: F401
 
@@ -15,32 +13,3 @@ from classad import classad  # noqa: F401
 def input_from_file(fname):
     with open(fname) as fd:
         return eval(fd.read())
-
-
-def raw_input_from_file(fname):
-    with open(fname) as fd:
-        return fd.read()
-
-
-def compare_dfs(df1, df2):
-    """
-    for some reason df.equals does not work here
-    but if I compare cell by cell it works
-    :type df1: :class:`pd.DataFrame`
-    :arg df1: data frame instance
-    :type df2: :class:`pd.DataFrame`
-    :arg df2: data frame instance
-    :rtype: :obj:`bool` - True if equal
-
-    """
-    if df1.shape[0] != df2.shape[0]:
-        return False
-    if df1.shape[1] != df2.shape[1]:
-        return False
-    rc = True
-    for i in range(df1.shape[0]):
-        for j in range(df1.shape[1]):
-            if df1.iloc[i, j] != df2.iloc[i, j]:
-                rc = False
-                break
-    return rc


### PR DESCRIPTION
The `resource_requests` channel has always accepted or rejected _all_ requests for a given GlideinWMS entry type.  More granular behavior is desired.  With this PR, the following type of configuration is allowed:

```.jsonnet
publishers: {
  fe_group_classads: {
    module: "decisionengine_modules.glideinwms.publishers.fe_group_classads",
    parameters: {
        "Grid": "@requests.ClientName != 'e1' and @entries.Other % 2 != 0",
        "AWS": "@requests.CollectorHost == 'col2.com'",
        "GCE": "@requests.CollectorHost == 'col3.com'",
    }
  }
}
```
where the keys `"Grid"`, `"AWS"`, and `"GCE"` correspond to the names of the logic-engine facts that evaluate to Boolean true.  The corresponding values are queries that are additionally executed on the corresponding requests dataframe.  The `@requests` and `@entries` tokens provide access to the merged dataframe fields of the GlideinWMS requests dataframe and the factory entries data frame, respectively.