### PR TITLE
Fix pyupgrade version for python 3.6 compatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,8 +44,8 @@ repos:
           - "prettier"
           - "prettier-plugin-toml@0.3.1"
   - repo: "https://github.com/asottile/pyupgrade"
-    rev: v2.31.0
-    # v2.32.0 requires python >= 3.7
+    rev: e695ecd365119ab4e5463f6e49bea5f4b7ca786b
+    # fix to v2.31.0, v2.32.0 requires python >= 3.7
     hooks:
       - id: pyupgrade
         args:


### PR DESCRIPTION
Putting the git commit hash instead of the version will fix the version to the one there

pyupgrade should stay to v2.31.0 because v2.32.0 