### PR TITLE
Enable token proxy hybrid GWMS configuration

### DIFF
--- a/src/decisionengine_modules/glideinwms/glide_frontend_element.py
+++ b/src/decisionengine_modules/glideinwms/glide_frontend_element.py
@@ -295,6 +295,8 @@ class GlideFrontendElement:
                 glidein_params[k] = eval(kexpr)
             # Add GLIDECLIENT_ReqNode to monitor orphaned glideins
             glidein_params["GLIDECLIENT_ReqNode"] = factory_pool_node
+            # TODO: Remove this classad once token/proxy hybrid configurations are no longer supported
+            glidein_params["CONTINUE_IF_NO_PROXY"] = "True"
 
             glidein_monitors = {k: count_jobs[k] for k in count_jobs}
             glidein_monitors["RunningHere"] = self.count_real_jobs[glideid]
@@ -450,8 +452,10 @@ class GlideFrontendElement:
             remove_excess_str=remove_excess_str,
         )
 
+        # TODO: Filter by credential type once token/proxy hybrid configurations are no longer supported
+        # credential_type=auth_method
         credentials_with_request = self.credential_plugin.get_credentials(
-            params_obj=params_obj, credential_type=auth_method, trust_domain=trust_domain
+            params_obj=params_obj, trust_domain=trust_domain
         )
 
         if not credentials_with_request:
@@ -472,10 +476,14 @@ class GlideFrontendElement:
                 continue
 
             if not cred.supports_auth_method(auth_method):
-                self.logger.warning(
-                    f"Credential {cred.type} does not match auth method {auth_method} (for {params_obj.request_name}), skipping..."
-                )
-                continue
+                # TODO: Remove this condition once token/proxy hybrid configurations are no longer supported
+                if auth_method == "grid_proxy" and "scitoken" in cred.type:
+                    self.logger.debug("Sending scitoken along with grid-proxy")
+                else:
+                    self.logger.warning(
+                        f"Credential {cred.type} does not match auth method {auth_method} (for {params_obj.request_name}), skipping..."
+                    )
+                    continue
 
             if cred.trust_domain != trust_domain:
                 self.logger.warning(
@@ -1644,6 +1652,8 @@ class GlideFrontendElementFOM(GlideFrontendElement):
                 glidein_params[k] = eval(kexpr)
             # Add GLIDECLIENT_ReqNode to monitor orphaned glideins
             glidein_params["GLIDECLIENT_ReqNode"] = factory_pool_node
+            # TODO: Remove this classad once token/proxy hybrid configurations are no longer supported
+            glidein_params["CONTINUE_IF_NO_PROXY"] = "True"
 
             glidein_monitors = {k: count_jobs[k] for k in count_jobs}
             glidein_monitors["RunningHere"] = self.count_real_jobs[glideid]


### PR DESCRIPTION
These changes enable token/proxy hybrid authentication for the DE. It reproduces the same behavior as the GWMS Frontend. When authenticating with a CE using the `proxy` authentication method, if a SciToken is available, it will be sent along with the proxy. This PR also ensures that the `CONTINUE_IF_NO_PROXY` parameter is always "True".