### PR TITLE
Set upper limit version for flake8.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ devel_req = [
     "pytest-cov >= 2.11.1",
     "pytest-flake8 >= 1.0.7",
     "pytest-xdist[psutil] >= 2.3.0",
+    "flake8 >= 4.0.0, < 5.0.0",  # https://github.com/tholo/pytest-flake8/issues/87
     "coverage == 6.1.2",  # https://github.com/nedbat/coveragepy/issues/1300
     "tabulate >= 0.8.8",
     "toml >= 0.10.2",


### PR DESCRIPTION
This is needed to have pytest-flake8 and flake8 versions working together.