### PR TITLE
Fix de_client call

### DIFF
--- a/src/decisionengine_modules/glideinwms/DEConfigSource.py
+++ b/src/decisionengine_modules/glideinwms/DEConfigSource.py
@@ -21,7 +21,7 @@ class DEConfigSource(ConfigSource):
 
     def load_config(self):
         try:
-            de_config = de_client.main(["--port", self.port, "--host", self.host, "--show-de-config"])
+            de_config = de_client.main(["--port", self.port, "--host", self.host, "--show-de-config"], logger_name=None)
             de_config = json.loads(de_config, object_hook=OrderedDict)["glideinwms"]
             return de_config
         except Exception as e:


### PR DESCRIPTION
This is required to allow de_client to get its output returned as text string rather then using a logger.
This fixes an issue when using `decisionengine_modules/glideinwms/configure_gwms_frontend.py` to generate GWMS configuration from `glideinwms.libsonnet`
Thanks to Kyle for the help to get the issue fixed.