### PR TITLE
modifications to fix source loggers

### DIFF
--- a/src/decisionengine_modules/AWS/sources/AWSInstancePerformance.py
+++ b/src/decisionengine_modules/AWS/sources/AWSInstancePerformance.py
@@ -13,8 +13,8 @@ from decisionengine.framework.modules.Source import Parameter
 @Source.supports_config(Parameter("data_file", type=str, comment="CSV cost data file"))
 @Source.produces(Performance_Data=pd.DataFrame)
 class AWSInstancePerformance(Source.Source):
-    def __init__(self, config):
-        super().__init__(config)
+    def __init__(self, config, logger):
+        super().__init__(config, logger)
         self.data_file = config.get("data_file")
 
     def acquire(self):

--- a/src/decisionengine_modules/AWS/sources/AWSJobLimits.py
+++ b/src/decisionengine_modules/AWS/sources/AWSJobLimits.py
@@ -19,8 +19,8 @@ _TO = 20
 @Source.supports_config(Parameter("data_file", type=str, comment="CSV job limits data file"))
 @Source.produces(Job_Limits=pd.DataFrame)
 class AWSJobLimits(Source.Source):
-    def __init__(self, config):
-        super().__init__(config)
+    def __init__(self, config, logger):
+        super().__init__(config, logger)
         self.data_file = config["data_file"]
 
     def acquire(self):

--- a/src/decisionengine_modules/AWS/sources/AWSOccupancy.py
+++ b/src/decisionengine_modules/AWS/sources/AWSOccupancy.py
@@ -149,8 +149,8 @@ and the entries in the lists (e.g. "RegionName1") are the name of a region (eg. 
 )
 @Source.produces(AWS_Occupancy=pd.DataFrame)
 class AWSOccupancy(Source.Source):
-    def __init__(self, configdict):
-        super().__init__(configdict)
+    def __init__(self, configdict, logger):
+        super().__init__(configdict, logger)
         self.config_file = configdict["occupancy_configuration"]
 
     def acquire(self):

--- a/src/decisionengine_modules/AWS/sources/AWSSpotPrice.py
+++ b/src/decisionengine_modules/AWS/sources/AWSSpotPrice.py
@@ -194,8 +194,8 @@ all instances is acquired.""",
 )
 @Source.produces(provisioner_resource_spot_prices=pd.DataFrame)
 class AWSSpotPrice(Source.Source):
-    def __init__(self, config_dict):
-        super().__init__(config_dict)
+    def __init__(self, config_dict, logger):
+        super().__init__(config_dict, logger)
         self.config_file = config_dict["spot_price_configuration"]
 
     def acquire(self):

--- a/src/decisionengine_modules/AWS/sources/BillingInfo.py
+++ b/src/decisionengine_modules/AWS/sources/BillingInfo.py
@@ -38,8 +38,8 @@ from decisionengine_modules.AWS.sources import DEAccountContants
 )
 @Source.produces(AWS_Billing_Info=pd.DataFrame, AWS_Billing_Rate=pd.DataFrame)
 class BillingInfo(Source.Source):
-    def __init__(self, config):
-        super().__init__(config)
+    def __init__(self, config, logger):
+        super().__init__(config, logger)
         acconts_config_file = config["billing_configuration"]
         self.billing_files_location = config["dst_dir_for_s3_files"]
         self.verbose_flag = int(config["verbose_flag"])

--- a/src/decisionengine_modules/AWS/sources/FinancialParameters.py
+++ b/src/decisionengine_modules/AWS/sources/FinancialParameters.py
@@ -20,8 +20,8 @@ _SAMPLE_CONFIG = {
 )
 @Source.produces(financial_params=pandas.DataFrame)
 class FinancialParameters(Source.Source):
-    def __init__(self, config):
-        super().__init__(config)
+    def __init__(self, config, logger):
+        super().__init__(config, logger)
         self.financial_parameters_dict = config.get("financial_parameters")
 
     # The DataBlock given to the source is t=0

--- a/src/decisionengine_modules/AWS/sources/LocalCapacity.py
+++ b/src/decisionengine_modules/AWS/sources/LocalCapacity.py
@@ -6,8 +6,8 @@ from decisionengine.framework.modules import Source
 
 @Source.produces(local_slots=int)
 class LocalCapacity(Source.Source):
-    def __init__(self, params_dict):
-        super().__init__(params_dict)
+    def __init__(self, params_dict, logger):
+        super().__init__(params_dict, logger)
 
     # The DataBlock given to the source is t=0
     def acquire(self):

--- a/src/decisionengine_modules/AWS/tests/test_AWSInstancePerformance.py
+++ b/src/decisionengine_modules/AWS/tests/test_AWSInstancePerformance.py
@@ -22,7 +22,7 @@ expected_pandas_df = (
 
 @pytest.fixture
 def aws_instance_performance():
-    return AWSInstancePerformance.AWSInstancePerformance(config)
+    return AWSInstancePerformance.AWSInstancePerformance(config, logger=None)
 
 
 def test_produces(aws_instance_performance):

--- a/src/decisionengine_modules/AWS/tests/test_AWSJobLimits.py
+++ b/src/decisionengine_modules/AWS/tests/test_AWSJobLimits.py
@@ -22,7 +22,7 @@ expected_pandas_df = (
 
 @pytest.fixture
 def aws_job_limits():
-    return AWSJobLimits.AWSJobLimits(config)
+    return AWSJobLimits.AWSJobLimits(config, logger=None)
 
 
 def test_produces(aws_job_limits):

--- a/src/decisionengine_modules/GCE/sources/GCEBillingInfo.py
+++ b/src/decisionengine_modules/GCE/sources/GCEBillingInfo.py
@@ -21,8 +21,8 @@ from decisionengine.framework.modules.Source import Parameter
 )
 @Source.produces(GCE_Billing_Info=pd.DataFrame)
 class GCEBillingInfo(Source.Source):
-    def __init__(self, config):
-        super().__init__(config)
+    def __init__(self, config, logger):
+        super().__init__(config, logger)
         # Load configuration "constants"
         self.projectId = config.get("projectId")
         self.credentialsProfileName = config.get("credentialsProfileName")  # NOT CURRENTLY USED

--- a/src/decisionengine_modules/GCE/sources/GCEInstancePerformance.py
+++ b/src/decisionengine_modules/GCE/sources/GCEInstancePerformance.py
@@ -14,8 +14,8 @@ from decisionengine.framework.modules.Source import Parameter
 @Source.supports_config(Parameter("csv_file", type=str, comment="path to CSV file"))
 @Source.produces(GCE_Instance_Performance=pd.DataFrame)
 class GCEInstancePerformance(Source.Source):
-    def __init__(self, config):
-        super().__init__(config)
+    def __init__(self, config, logger):
+        super().__init__(config, logger)
         self.csv_file = config.get("csv_file")
         if not self.csv_file:
             raise RuntimeError("No csv file found in configuration")

--- a/src/decisionengine_modules/GCE/sources/GceOccupancy.py
+++ b/src/decisionengine_modules/GCE/sources/GceOccupancy.py
@@ -31,8 +31,8 @@ _RETRY_TIMEOUT = 10
 )
 @Source.produces(GCE_Occupancy=pd.DataFrame)
 class GceOccupancy(Source.Source):
-    def __init__(self, config):
-        super().__init__(config)
+    def __init__(self, config, logger):
+        super().__init__(config, logger)
         os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = config["credential"]
         credentials, self.project = google.auth.default()
 

--- a/src/decisionengine_modules/NERSC/sources/NerscAllocationInfo.py
+++ b/src/decisionengine_modules/NERSC/sources/NerscAllocationInfo.py
@@ -41,8 +41,8 @@ class NerscAllocationInfo(Source.Source):
     Information of allocations on NERSC machines
     """
 
-    def __init__(self, config):
-        super().__init__(config)
+    def __init__(self, config, logger):
+        super().__init__(config, logger)
 
         self.constraints = config.get("constraints")
         if not isinstance(self.constraints, dict):

--- a/src/decisionengine_modules/NERSC/sources/NerscInstancePerformance.py
+++ b/src/decisionengine_modules/NERSC/sources/NerscInstancePerformance.py
@@ -14,8 +14,8 @@ from decisionengine.framework.modules.Source import Parameter
 @Source.supports_config(Parameter("csv_file", type=str, comment="path to CSV file"))
 @Source.produces(Nersc_Instance_Performance=pd.DataFrame)
 class NerscInstancePerformance(Source.Source):
-    def __init__(self, config):
-        super().__init__(config)
+    def __init__(self, config, logger):
+        super().__init__(config, logger)
         self.csv_file = config.get("csv_file")
         if not self.csv_file:
             raise RuntimeError("No csv file found in configuration")

--- a/src/decisionengine_modules/NERSC/sources/NerscJobInfo.py
+++ b/src/decisionengine_modules/NERSC/sources/NerscJobInfo.py
@@ -38,8 +38,8 @@ class NerscJobInfo(Source.Source):
     Information of jobs on NERSC machines
     """
 
-    def __init__(self, config):
-        super().__init__(config)
+    def __init__(self, config, logger):
+        super().__init__(config, logger)
         self.constraints = config.get("constraints")
         self.max_retries = config.get("max_retries", _MAX_RETRIES)
         self.retry_backoff_factor = config.get("retry_backoff_factor", _RETRY_BACKOFF_FACTOR)

--- a/src/decisionengine_modules/Rigetti/sources/Rigetti_Balance.py
+++ b/src/decisionengine_modules/Rigetti/sources/Rigetti_Balance.py
@@ -58,11 +58,11 @@ class RigettiBalance(Source.Source):
     Billing status for the Rigetti systems
     """
 
-    def __init__(self, config):
+    def __init__(self, config, logger):
         """
         Read in our toml files and build a client we can use
         """
-        super().__init__(config)
+        super().__init__(config, logger)
 
         self.constraints = config.get("constraints")
         if not isinstance(self.constraints, dict):

--- a/src/decisionengine_modules/Rigetti/sources/Rigetti_BillingInfo.py
+++ b/src/decisionengine_modules/Rigetti/sources/Rigetti_BillingInfo.py
@@ -70,11 +70,11 @@ class RigettiBillingInfo(Source.Source):
     Billing costs for the Rigetti systems
     """
 
-    def __init__(self, config):
+    def __init__(self, config, logger):
         """
         Read in our toml files and build a client we can use
         """
-        super().__init__(config)
+        super().__init__(config, logger)
 
         self.constraints = config.get("constraints")
         if not isinstance(self.constraints, dict):

--- a/src/decisionengine_modules/glideinwms/sources/factory_client.py
+++ b/src/decisionengine_modules/glideinwms/sources/factory_client.py
@@ -9,8 +9,8 @@ from decisionengine_modules.htcondor.sources import source
 
 @Source.produces(factoryclient_manifests=pd.DataFrame)
 class FactoryClientManifests(source.ResourceManifests):
-    def __init__(self, config):
-        super().__init__(config)
+    def __init__(self, config, logger):
+        super().__init__(config, logger)
         self.constraint = f'({self.constraint})&&(glideinmytype=="glidefactoryclient")'
         self.subsystem_name = "any"
 

--- a/src/decisionengine_modules/glideinwms/sources/factory_entries.py
+++ b/src/decisionengine_modules/glideinwms/sources/factory_entries.py
@@ -37,8 +37,8 @@ ENTRY_TYPES = {
 )
 @Source.produces(Factory_Entries=pandas.DataFrame)
 class FactoryEntries(Source.Source):
-    def __init__(self, config):
-        super().__init__(config)
+    def __init__(self, config, logger):
+        super().__init__(config, logger)
         self.condor_config = config.get("condor_config")
         self.factories = config.get("factories", [])
 

--- a/src/decisionengine_modules/glideinwms/sources/factory_global.py
+++ b/src/decisionengine_modules/glideinwms/sources/factory_global.py
@@ -30,13 +30,13 @@ from decisionengine_modules.util.retry_function import retry_wrapper
 )
 @Source.produces(factoryglobal_manifests=pandas.DataFrame)
 class FactoryGlobalManifests(Source.Source):
-    def __init__(self, config):
+    def __init__(self, config, logger):
         if not config:
             config = {}
         if not isinstance(config, dict):
             raise RuntimeError("parameters for module config should be a dict")
 
-        super().__init__(config)
+        super().__init__(config, logger)
         self.condor_config = config.get("condor_config")
         self.factories = config.get("factories", [])
 

--- a/src/decisionengine_modules/htcondor/sources/job_q.py
+++ b/src/decisionengine_modules/htcondor/sources/job_q.py
@@ -20,13 +20,13 @@ from decisionengine_modules.htcondor import htcondor_query
 )
 @Source.produces(job_manifests=pandas.DataFrame)
 class JobQ(Source.Source):
-    def __init__(self, config):
+    def __init__(self, config, logger):
         """
         In config files such as job_classification.jsonnet or Nersc.jsonnet,
         put a dictionary named correction_map with keys corresponding to classad_attrs
         and values that the operators want to be default values for the classad_attrs.
         """
-        super().__init__(config)
+        super().__init__(config, logger)
         self.collector_host = config.get("collector_host")
         self.schedds = config.get("schedds", [None])
         self.condor_config = config.get("condor_config")

--- a/src/decisionengine_modules/htcondor/sources/slots.py
+++ b/src/decisionengine_modules/htcondor/sources/slots.py
@@ -9,8 +9,8 @@ from decisionengine_modules.htcondor.sources import source
 
 @Source.produces(startd_manifests=pandas.DataFrame)
 class StartdManifests(source.ResourceManifests):
-    def __init__(self, config):
-        super().__init__(config)
+    def __init__(self, config, logger):
+        super().__init__(config, logger)
 
     def acquire(self):
         self.logger.debug("in StartdManifests acquire")

--- a/src/decisionengine_modules/htcondor/sources/source.py
+++ b/src/decisionengine_modules/htcondor/sources/source.py
@@ -21,7 +21,7 @@ from decisionengine_modules.htcondor import htcondor_query
     Parameter("correction_map", default={}),
 )
 class ResourceManifests(Source.Source, metaclass=abc.ABCMeta):
-    def __init__(self, config):
+    def __init__(self, config, logger):
         """
         In config files such as job_classification.jsonnet or Nersc.jsonnet,
         put a dictionary named correction_map with keys corresponding to classad_attrs
@@ -30,7 +30,7 @@ class ResourceManifests(Source.Source, metaclass=abc.ABCMeta):
         because some classes that extend this class might not have correction_map
         avaiable in its config file.
         """
-        super().__init__(config)
+        super().__init__(config, logger)
         self.collector_host = config.get("collector_host")
         self.condor_config = config.get("condor_config")
         self.constraint = config.get("constraint", True)

--- a/src/decisionengine_modules/tests/test_GCEBillingInfo.py
+++ b/src/decisionengine_modules/tests/test_GCEBillingInfo.py
@@ -31,7 +31,7 @@ config_billing_info = {
 
 
 def test_produces():
-    bi_pub = GCEBillingInfo.GCEBillingInfo(config_billing_info)
+    bi_pub = GCEBillingInfo.GCEBillingInfo(config_billing_info, logger=None)
     assert bi_pub._produces == {"GCE_Billing_Info": pandas.DataFrame}
 
 

--- a/src/decisionengine_modules/tests/test_GCEInstancePerformanceInfo.py
+++ b/src/decisionengine_modules/tests/test_GCEInstancePerformanceInfo.py
@@ -17,14 +17,16 @@ EXPECTED_PANDAS_DF = pd.read_csv(CONFIG.get("csv_file"))
 
 _PRODUCES = {"GCE_Instance_Performance": pd.DataFrame}
 
+LOGGER = None
+
 
 def test_produces():
-    gce_price_performance = GCEInstancePerformance.GCEInstancePerformance(CONFIG)
+    gce_price_performance = GCEInstancePerformance.GCEInstancePerformance(CONFIG, LOGGER)
     assert gce_price_performance._produces == _PRODUCES
 
 
 def test_acquire():
-    gce_price_performance = GCEInstancePerformance.GCEInstancePerformance(CONFIG)
+    gce_price_performance = GCEInstancePerformance.GCEInstancePerformance(CONFIG, LOGGER)
     res = gce_price_performance.acquire()
     verify_products(gce_price_performance, res)
     assert EXPECTED_PANDAS_DF.equals(res.get("GCE_Instance_Performance"))

--- a/src/decisionengine_modules/tests/test_GceOccupancy.py
+++ b/src/decisionengine_modules/tests/test_GceOccupancy.py
@@ -49,12 +49,12 @@ def replace_google_auth():
 
 
 def test_produces(replace_google_auth):
-    assert GceOccupancy.GceOccupancy(CONFIG)._produces == _PRODUCES
+    assert GceOccupancy.GceOccupancy(CONFIG, logger=None)._produces == _PRODUCES
 
 
 def test_acquire(replace_google_auth):
     with mock.patch.object(googleapiclient.discovery, "build", return_value=MockClient()):
-        occupancy = GceOccupancy.GceOccupancy(CONFIG)
+        occupancy = GceOccupancy.GceOccupancy(CONFIG, logger=None)
         res = occupancy.acquire()
         verify_products(occupancy, res)
         assert EXPECTED_DF.equals(res.get("GCE_Occupancy"))

--- a/src/decisionengine_modules/tests/test_NerscAllocationInfo.py
+++ b/src/decisionengine_modules/tests/test_NerscAllocationInfo.py
@@ -54,7 +54,7 @@ def nersc_allocations():
             },
         },
     }
-    return NerscAllocationInfo.NerscAllocationInfo(config)
+    return NerscAllocationInfo.NerscAllocationInfo(config, logger=None)
 
 
 def test_produces(nersc_allocations):

--- a/src/decisionengine_modules/tests/test_NerscInstancePerformance.py
+++ b/src/decisionengine_modules/tests/test_NerscInstancePerformance.py
@@ -20,14 +20,16 @@ EXPECTED_PANDAS_DF = pd.read_csv(CONFIG.get("csv_file"))
 
 _PRODUCES = {"Nersc_Instance_Performance": pd.DataFrame}
 
+LOGGER = None
+
 
 def test_produces():
-    nersc_instance_performance = NerscInstancePerformance.NerscInstancePerformance(CONFIG)
+    nersc_instance_performance = NerscInstancePerformance.NerscInstancePerformance(CONFIG, LOGGER)
     assert nersc_instance_performance._produces == _PRODUCES
 
 
 def test_acquire():
-    nersc_instance_performance = NerscInstancePerformance.NerscInstancePerformance(CONFIG)
+    nersc_instance_performance = NerscInstancePerformance.NerscInstancePerformance(CONFIG, LOGGER)
     res = nersc_instance_performance.acquire()
     verify_products(nersc_instance_performance, res)
     assert EXPECTED_PANDAS_DF.equals(res.get("Nersc_Instance_Performance"))

--- a/src/decisionengine_modules/tests/test_NerscJobInfo.py
+++ b/src/decisionengine_modules/tests/test_NerscJobInfo.py
@@ -43,7 +43,7 @@ def nersc_job_info():
             },
         },
     }
-    return NerscJobInfo.NerscJobInfo(config)
+    return NerscJobInfo.NerscJobInfo(config, logger=None)
 
 
 def test_produces(nersc_job_info):

--- a/src/decisionengine_modules/tests/test_factory_client.py
+++ b/src/decisionengine_modules/tests/test_factory_client.py
@@ -28,10 +28,12 @@ CONFIG_BAD = {
     "collector_host": "dummy_collector.fnal.gov",
 }
 
+LOGGER = None
+
 
 @pytest.fixture
 def factory_client_instance():
-    return factory_client.FactoryClientManifests(CONFIG)
+    return factory_client.FactoryClientManifests(CONFIG, LOGGER)
 
 
 def test_produces(factory_client_instance):
@@ -48,6 +50,6 @@ def test_acquire_live(factory_client_instance):
 
 
 def test_acquire_bad():
-    fc = factory_client.FactoryClientManifests(CONFIG_BAD)
+    fc = factory_client.FactoryClientManifests(CONFIG_BAD, LOGGER)
     fc_df = fc.acquire()
     assert len(fc_df["factoryclient_manifests"]) == 0

--- a/src/decisionengine_modules/tests/test_factory_entries.py
+++ b/src/decisionengine_modules/tests/test_factory_entries.py
@@ -60,32 +60,34 @@ CONFIG_FACTORY_ENTRIES_CORMAP = {
     ],
 }
 
+LOGGER = None
+
 
 def test_produces():
-    entries = factory_entries.FactoryEntries(CONFIG_FACTORY_ENTRIES)
+    entries = factory_entries.FactoryEntries(CONFIG_FACTORY_ENTRIES, LOGGER)
     assert entries._produces == {"Factory_Entries": pd.DataFrame}
 
 
 def test_acquire():
-    entries = factory_entries.FactoryEntries(CONFIG_FACTORY_ENTRIES)
+    entries = factory_entries.FactoryEntries(CONFIG_FACTORY_ENTRIES, LOGGER)
     with mock.patch.object(htcondor_query.CondorStatus, "fetch", return_value=utils.input_from_file(FIXTURE_FILE)):
         pprint.pprint(entries.acquire())
 
 
 def test_acquire_live():
-    entries = factory_entries.FactoryEntries(CONFIG_FACTORY_ENTRIES)
+    entries = factory_entries.FactoryEntries(CONFIG_FACTORY_ENTRIES, LOGGER)
     pprint.pprint(entries.acquire())
 
 
 def test_acquire_bad():
-    entries = factory_entries.FactoryEntries(CONFIG_FACTORY_ENTRIES_BAD)
+    entries = factory_entries.FactoryEntries(CONFIG_FACTORY_ENTRIES_BAD, LOGGER)
     result = entries.acquire()
     for df in result.values():
         assert df.dropna().empty
 
 
 def test_acquire_bad_with_timeout():
-    entries = factory_entries.FactoryEntries(CONFIG_FACTORY_ENTRIES_BAD_WITH_TIMEOUT)
+    entries = factory_entries.FactoryEntries(CONFIG_FACTORY_ENTRIES_BAD_WITH_TIMEOUT, LOGGER)
     start = time.time()
     result = entries.acquire()
     end = time.time()
@@ -99,7 +101,7 @@ def test_acquire_correctionmap():
     df1 = pd.DataFrame(data={"GLIDEIN_Resource_Slots": ["DummySlots", "DummySlots"]})
     df2 = pd.DataFrame(data={"GLIDEIN_CMSSite": ["DummySite", "DummySite"]})
 
-    entries = factory_entries.FactoryEntries(CONFIG_FACTORY_ENTRIES_CORMAP)
+    entries = factory_entries.FactoryEntries(CONFIG_FACTORY_ENTRIES_CORMAP, LOGGER)
     with mock.patch.object(htcondor_query.CondorStatus, "fetch", return_value=utils.input_from_file(FIXTURE_FILE)):
         all_entries = entries.acquire()
         dummypd = all_entries["Factory_Entries"].xs("Grid")

--- a/src/decisionengine_modules/tests/test_factory_global.py
+++ b/src/decisionengine_modules/tests/test_factory_global.py
@@ -48,31 +48,33 @@ CONFIG_BAD_WITH_TIMEOUT = {
     ],
 }
 
+LOGGER = None
+
 
 def test_produces():
-    fg = factory_global.FactoryGlobalManifests(CONFIG)
+    fg = factory_global.FactoryGlobalManifests(CONFIG, LOGGER)
     assert fg._produces == {"factoryglobal_manifests": pandas.DataFrame}
 
 
 def test_acquire():
-    fg = factory_global.FactoryGlobalManifests(CONFIG)
+    fg = factory_global.FactoryGlobalManifests(CONFIG, LOGGER)
     with mock.patch.object(htcondor_query.CondorStatus, "fetch", return_value=utils.input_from_file(FIXTURE_FILE)):
         pprint.pprint(fg.acquire())
 
 
 def test_acquire_live():
-    fg = factory_global.FactoryGlobalManifests(CONFIG)
+    fg = factory_global.FactoryGlobalManifests(CONFIG, LOGGER)
     pprint.pprint(fg.acquire())
 
 
 def test_acquire_bad():
-    fg = factory_global.FactoryGlobalManifests(CONFIG_BAD)
+    fg = factory_global.FactoryGlobalManifests(CONFIG_BAD, LOGGER)
     fg_df = fg.acquire()
     assert (fg_df["factoryglobal_manifests"] is None) or (len(fg_df["factoryglobal_manifests"]) == 0)
 
 
 def test_acquire_bad_with_timeout():
-    fg = factory_global.FactoryGlobalManifests(CONFIG_BAD_WITH_TIMEOUT)
+    fg = factory_global.FactoryGlobalManifests(CONFIG_BAD_WITH_TIMEOUT, LOGGER)
     start = time.time()
     fg_df = fg.acquire()
     end = time.time()

--- a/src/decisionengine_modules/tests/test_job_q.py
+++ b/src/decisionengine_modules/tests/test_job_q.py
@@ -25,7 +25,7 @@ def jobq_instance():
         "schedds": ["fermicloud122.fnal.gov"],
         "classad_attrs": ["ClusterId", "ProcId", "JobStatus"],
     }
-    return job_q.JobQ(config)
+    return job_q.JobQ(config, logger=None)
 
 
 def test_produces(jobq_instance):

--- a/src/decisionengine_modules/tests/test_slots.py
+++ b/src/decisionengine_modules/tests/test_slots.py
@@ -24,7 +24,7 @@ def slots_instance():
         "condor_config": "condor_config",
         "collector_host": "fermicloud122.fnal.gov",
     }
-    return slots.StartdManifests(config)
+    return slots.StartdManifests(config, logger=None)
 
 
 def test_produces(slots_instance):


### PR DESCRIPTION
**THIS PR CORRESPONDS TO PR#670 https://github.com/HEPCloud/decisionengine/pull/670 in decisionengine.**

Individual Source loggers were failing because of the addition of ChannelWorkers as different multiprocessing processes.

Each of the SourceWorker objects is a multiprocessing.Process that has its own logger based on the SOURCELOGGERNAME. Each SourceWorker also has a dict of Sources, each of which has its own logger which was based on the CHANNELLOGGERNAME, which is actually in another multiprocessing.Process. Any logging done by the Sources was thus not getting recorded.

I changed the design so that now the Sources get their logger from the SourceWorker; the logger is passed through as a parameter in the Source initialization.
