### PR TITLE
Disabling Python 3.6 and Fixing 3.9 Unit Tests in CI Workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.7"
+          - "3.8"
           - "3.9"
 
     name: Python ${{ matrix.python-version }} unit tests
@@ -55,7 +55,7 @@ jobs:
         with:
           path: glideinwms
           repository: glideinWMS/glideinwms
-          ref: branch_v3_9
+          ref: master
 
       - name: Cache pip
         uses: actions/cache@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.6"
+          # - "3.6"
           - "3.9"
 
     name: Python ${{ matrix.python-version }} unit tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          # - "3.6"
+          - "3.7"
           - "3.9"
 
     name: Python ${{ matrix.python-version }} unit tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ minversion = "6.0"
 addopts = "-l -v --durations=0 -n 4"
 log_level = "debug"
 testpaths = "src/decisionengine_modules"
-timeout = 120
+#timeout = 120
 filterwarnings = [
   "ignore::DeprecationWarning:M2Crypto"
 ] # Only deprecations in third-party software for now.

--- a/setup.py
+++ b/setup.py
@@ -33,11 +33,8 @@ runtime_require = [
     "requests >= 2.14.2",
     "urllib3 >= 1.26.2",
     "bill-calculator-hep >= 0.1.4",
-    "numpy == 1.19.5; python_version <= '3.6'",
     "numpy >= 1.19.5; python_version >= '3.7'",
-    "pandas == 1.1.5; python_version <= '3.6'",
     "pandas >= 1.5.3; python_version >= '3.7'",
-    "qcs-api-client >= 0.20.17; python_version <= '3.6'",
     "qcs-api-client >= 0.21.1; python_version >= '3.7'",
 ]
 
@@ -80,6 +77,7 @@ rpm_require.extend(__base_pip_requires)
 # Much of it comes out of decisionengine_modules.about.py
 setup(
     setup_requires=["setuptools >= 51.2", "wheel >= 0.36.2", "setuptools_scm >= 6.3.1"],
+    python_requires=">3.7.0",
     name=about.__title__,
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ runtime_require = [
     "numpy == 1.19.5; python_version <= '3.6'",
     "numpy >= 1.19.5; python_version >= '3.7'",
     "pandas == 1.1.5; python_version <= '3.6'",
-    "pandas >= 1.1.5; python_version >= '3.7'",
+    "pandas >= 1.5.3; python_version >= '3.7'",
     "qcs-api-client >= 0.20.17; python_version <= '3.6'",
     "qcs-api-client >= 0.21.1; python_version >= '3.7'",
 ]

--- a/src/decisionengine_modules/glideinwms/publishers/decisionenginemonitor.py
+++ b/src/decisionengine_modules/glideinwms/publishers/decisionenginemonitor.py
@@ -14,7 +14,8 @@ class DecisionEngineMonitorManifests(publisher.HTCondorManifests):
     def create_invalidate_constraint(self, requests_df):
         self.logger.debug("in DecisionEngineMonitorManifests create_invalidate_constraint")
         if not requests_df.empty:
-            for collector_host, request_group in requests_df.groupby(["CollectorHost"]):
+            # grouper has to be a string instead of a list with the string
+            for collector_host, request_group in requests_df.groupby("CollectorHost"):
                 client_names = list(set(request_group["GlideClientName"]))
                 client_names.sort()
                 if client_names:

--- a/src/decisionengine_modules/glideinwms/publishers/decisionenginemonitor.py
+++ b/src/decisionengine_modules/glideinwms/publishers/decisionenginemonitor.py
@@ -14,7 +14,7 @@ class DecisionEngineMonitorManifests(publisher.HTCondorManifests):
     def create_invalidate_constraint(self, requests_df):
         self.logger.debug("in DecisionEngineMonitorManifests create_invalidate_constraint")
         if not requests_df.empty:
-            # grouper has to be a string instead of a list with the string
+            # Starting pandas 1.5.0, groupby instruction, when iterating, returns a single element only when the grouper is a string (not a list)
             for collector_host, request_group in requests_df.groupby("CollectorHost"):
                 client_names = list(set(request_group["GlideClientName"]))
                 client_names.sort()

--- a/src/decisionengine_modules/glideinwms/publishers/fe_group_classads.py
+++ b/src/decisionengine_modules/glideinwms/publishers/fe_group_classads.py
@@ -41,7 +41,7 @@ class GlideinWMSManifests(publisher.HTCondorManifests):
         if requests_df.empty:
             return
 
-        # grouper has to be a string instead of a list with the string
+        # Starting pandas 1.5.0, groupby instruction, when iterating, returns a single element only when the grouper is a string (not a list)
         for collector_host, request_group in requests_df.groupby("CollectorHost"):
             client_names = list(set(request_group["ClientName"]))
             client_names.sort()

--- a/src/decisionengine_modules/glideinwms/publishers/fe_group_classads.py
+++ b/src/decisionengine_modules/glideinwms/publishers/fe_group_classads.py
@@ -41,7 +41,8 @@ class GlideinWMSManifests(publisher.HTCondorManifests):
         if requests_df.empty:
             return
 
-        for collector_host, request_group in requests_df.groupby(["CollectorHost"]):
+        # grouper has to be a string instead of a list with the string
+        for collector_host, request_group in requests_df.groupby("CollectorHost"):
             client_names = list(set(request_group["ClientName"]))
             client_names.sort()
             if client_names:

--- a/src/decisionengine_modules/glideinwms/publishers/glideclientglobal.py
+++ b/src/decisionengine_modules/glideinwms/publishers/glideclientglobal.py
@@ -14,7 +14,7 @@ class GlideClientGlobalManifests(publisher.HTCondorManifests):
     def create_invalidate_constraint(self, dataframe):
         self.logger.debug("in GlideClientGlobalManifests create_invalidate_constraint")
         if not dataframe.empty:
-            # grouper has to be a string instead of a list with the string
+            # Starting pandas 1.5.0, groupby instruction, when iterating, returns a single element only when the grouper is a string (not a list)
             for collector_host, group in dataframe.groupby("CollectorHost"):
                 client_names = list(set(group["ClientName"]))
                 client_names.sort()

--- a/src/decisionengine_modules/glideinwms/publishers/glideclientglobal.py
+++ b/src/decisionengine_modules/glideinwms/publishers/glideclientglobal.py
@@ -14,7 +14,8 @@ class GlideClientGlobalManifests(publisher.HTCondorManifests):
     def create_invalidate_constraint(self, dataframe):
         self.logger.debug("in GlideClientGlobalManifests create_invalidate_constraint")
         if not dataframe.empty:
-            for collector_host, group in dataframe.groupby(["CollectorHost"]):
+            # grouper has to be a string instead of a list with the string
+            for collector_host, group in dataframe.groupby("CollectorHost"):
                 client_names = list(set(group["ClientName"]))
                 client_names.sort()
                 if client_names:

--- a/src/decisionengine_modules/glideinwms/resource_dist_plugins.py
+++ b/src/decisionengine_modules/glideinwms/resource_dist_plugins.py
@@ -24,8 +24,8 @@ def order_resources(resources, logger=None):
             df = fom_df[["EntryName", column_name]]
             # Rename the entry type specific FOM columns to just 'fom'
             df = df.rename(columns={column_name: "FOM"})
-            # Append the results
-            rss_foms = rss_foms.append(df)
+            # Conacatenate the results
+            rss_foms = pd.concat([rss_foms, df])
         elif logger is not None:
             logger.info(f"{rss} does not have any entries to order")
     try:

--- a/src/decisionengine_modules/glideinwms/transforms/job_clustering.py
+++ b/src/decisionengine_modules/glideinwms/transforms/job_clustering.py
@@ -62,7 +62,7 @@ class JobClustering(Transform.Transform):
         except ValueError:
             self.logger.exception("Unable to retrieve job manifests data block")
             return {"job_clusters": self.EMPTY_JOB_CLUSTER}
-        except pd.core.computation.ops.UndefinedVariableError:
+        except pd.errors.UndefinedVariableError:
             self.logger.exception("Unable to retrieve job manifests data block")
             return {"job_clusters": self.EMPTY_JOB_CLUSTER}
 
@@ -112,7 +112,7 @@ class JobClustering(Transform.Transform):
                 "Unable to calculate totals from job manifests, may have missing classads or incorrect classad names"
             )
             return {"job_clusters": self.EMPTY_JOB_CLUSTER}
-        except pd.core.computation.ops.UndefinedVariableError:
+        except pd.errors.UndefinedVariableError:
             self.logger.exception(
                 "Unable to calculate totals from job manifests, may have missing classads or incorrect classad names"
             )


### PR DESCRIPTION
As part of completing my activity on the PR for making CONTINUE_IF_NO_PROXY a configurable attribute (#457), an attempt was made to push the changes to the respective branch on the decisionengine codebase. The CI workflow reported that python 3.6 and 3.9 unit tests did not pass. The suggestion was to run the unit tests locally to understand what might be causing the tests to fail.

When the unit tests were run locally, no errors were reported and all the unit tests passed. This meant that there could be a difference in the packages (dependencies) in my dev environment versus what was being installed in the environment that the CI workflow was setting up. Specifically, 
* for 3.9 python unit tests, there were at least a few libraries, one of them being pandas, that were surely at a higher version in the CI workflow than on the dev environment (something that Kyle had previously pointed out) 
* for python 3.6 unit tests, the error message in the CI workflow said “Version 3.6 was not found in the local cache. Error: The version '3.6' with architecture 'x64' was not found for Ubuntu 22.04.” The assumption was that python 2.6 is no longer supported in Ubuntu 22.04 (64-bit architecture) and Marco confirmed that this was indeed the case.

The recommendation was to disable python 3.6 unit tests in the CI workflow as python 3.6 is not supported. Further for python 3.9, separately investigate further to identify the differences in dependencies (versions, especially) to understand how the fixes can be made for unit tests to be successful as it is the case when these tests are run locally.

Must complete the following [non-blocking]:
- [x] https://github.com/glideinWMS/glideinwms/issues/300

## UPDATE 
Following are the specific details pertaining to the investigation behind why python3.9 unit tests were failing (these are also included in the commit description):
1.  #### The error message in the Github action for "Run Python 3.9 unit tests" says: `src/decisionengine_modules/glideinwms/transforms/job_clustering.py:115: AttributeError: module 'pandas.core.computation.ops' has no attribute 'UndefinedVariableError'`
    - The version of `pandas` on my dev environment was at version 1.1.5 but pandas installed during the CI workflow was at 1.5.3. For the CI workflow, python 3.9 was installed and due to the dependency requirement defined in `setup.py`, which is `pandas >= 1.1.5; python_version >= '3.7'`, pandas 2.0.1 was installed for the CI workflow.
    - For pandas versions 1.1.5 to 1.5.0 (exclusive), the attribute `UndefinedVariableError` was defined in the `pandas.core.computation.ops` module. As per the [release notes for pandas 1.5.0](https://pandas.pydata.org/pandas-docs/stable/whatsnew/v1.5.0.html), starting with 1.5.0, `UndefinedVariableError`, among others, are changed to be exposed via the `pandas.errors` module.
    - Possible solutions are: (1) freezing the version requirement of pandas, to be installed, to >=1.5.3 for python >= 3.7, or (2) modify the underlying python script to import the attribute 'UndefinedVariableError' based on the version of pandas installed.
    - Opted to go forward with updating pandas version to, at least, be 1.5.3 when python >=3.7 as we need to ensure the use of latest version of pandas moving forward as we do not want to run into similar issues again in the future.

2. #### Unit tests for a few python scripts in the codebase failed with the message `FutureWarning: In a future version of pandas, a length 1 tuple will be returned when iterating over a `groupby` with a grouper equal to a list of length 1. Don't supply a list with a single grouper to avoid this warning.` This ultimately was resulting in an `AssertionError` in the following unit tests:

    > .../tests/glideinwms/publishers/test_decisionenginemonitor.py::test_create_invalidate_constraint
    > .../tests/glideinwms/publishers/test_fe_group_classads.py::test_create_invalidate_constraint
    > .../tests/glideinwms/publishers/test_glideclientglobal.py::test_create_invalidate_constraint

    - In python scripts corresponding to those unit tests, the line `for collector_host, request_group in requests_df.groupby(["CollectorHost"]):` is what was causing the warning to be thrown. 
    - Upon testing locally on my machine, regardless of python 3.9.x, pandas 1.5.3 throws the warning but was successful with `assert` statements in the unit tests
    - Because the version of pandas, installed as part of the CI workflow, was >= 2.0.x, this led to the `assert` statements to fail. Because starting [pandas 1.5.x](https://pandas.pydata.org/docs/whatsnew/v1.5.0.html#other-deprecations), when using a grouper that is equal to a list of length 1, a length-1 tuple is returned rather than a single string element.
    - So, when using pandas 2.0.x, the FutureWarning was no longer thrown and keys were being returned as a tuple of length 1 instead of strings, which is what was observed when the CI workflow ran python 3.9 unit tests.
    - Changed the grouper to a string (in contrast to a list with the string). That is, `for ... in ...("col_name"):` instead of `for ... in ...(["col_name"]):`. This returned the keys as strings and not length-1 tuples, which is what the expected output of the unit tests were through the `assert` statements. 

3. #### Another message observed was `AttributeError: 'DataFrame' object has no attribute 'append'`
    - The CI workflow uses pandas >= 1.5.3 but since pandas 1.4.0, `pandas.DataFrame.append()` has been deprecated and with pandas >= 2.0.0, the append method has been completely removed. So, code that references `append()` reports an AttributeError.
    - As of pandas 2.0.x, the `concat()` method can be used to concatenate multiple dataframes and this was reflected in the file `src/decisionengine_modules/glideinwms/resource_dist_plugins.py`