### PR TITLE
Feature/vito pandas2 updates

### DIFF
--- a/src/decisionengine_modules/glideinwms/glide_frontend_element.py
+++ b/src/decisionengine_modules/glideinwms/glide_frontend_element.py
@@ -1823,7 +1823,7 @@ class GlideFrontendElementFOM(GlideFrontendElement):
                         # Default glidein_cpus to 1 if not defined
                         glidein_cpus = this_entry.get("GLIDEIN_CPUS", 1)
                         prop_match_cpu[key] = math.ceil(
-                            (prop_match_cpu.get(key, 0) + float(req_cpus * job_count)) / glidein_cpus
+                            (prop_match_cpu.get(key, 0) + float(req_cpus * job_count)) / float(glidein_cpus.iloc[0])
                         )
                         # Append FOM for all matches that are not in downtime
                         fom_matches = self.matches_with_fom(matches, entries_with_cpus)

--- a/src/decisionengine_modules/glideinwms/transforms/glidein_requests.py
+++ b/src/decisionengine_modules/glideinwms/transforms/glidein_requests.py
@@ -243,7 +243,7 @@ class GlideinRequestManifests(Transform.Transform):
                 self.logger.exception(f"Mismatch in manifest keys: {m_keys}, {g_keys}")
                 raise RuntimeError()
             for key in m_keys:
-                merged_manifests[key] = manifests[key].append(group_manifests[key], ignore_index=True)
+                merged_manifests[key] = pandas.concat([manifests[key], group_manifests[key]], ignore_index=True)
         else:
             merged_manifests = group_manifests
         return merged_manifests

--- a/src/decisionengine_modules/htcondor/sources/job_q.py
+++ b/src/decisionengine_modules/htcondor/sources/job_q.py
@@ -59,7 +59,7 @@ class JobQ(Source.Source):
                     # Add schedd name and collector host to job records
                     df["ScheddName"] = pandas.Series([schedd] * len(condor_q.stored_data))
                     df["CollectorHost"] = pandas.Series([collector_host] * len(condor_q.stored_data))
-                    dataframe = dataframe.append(df, ignore_index=True)
+                    dataframe = pandas.concat([dataframe, df], ignore_index=True)
             except htcondor_query.QueryError:
                 self.logger.warning(
                     f'Query error fetching job classads from schedd "{schedd}" in collector host(s) "{collector_host}".'


### PR DESCRIPTION
With pandas 2.x `DataFrame.append()` has been deprecated, it is needed to use `pandas.concat()` instead.
With pandas 2.x we also get a warning for a future deprecation:
```
FutureWarning: Calling float on a single element Series is deprecated and will raise a TypeError in the future. Use float(ser.iloc[0]) instead.
```
This has also been addressed.
