### PR TITLE
Update tests

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -19,30 +19,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout DE Modules
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: decisionengine_modules
 
       - name: checkout DE Framework
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: decisionengine
           repository: HEPCloud/decisionengine
 
       - name: checkout GlideinWMS for python3
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: glideinwms
           repository: glideinWMS/glideinwms
           ref: branch_v3_9
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
           architecture: "x64"
 
       - name: Cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           # This path is specific to Ubuntu
           path: ~/.cache/pip
@@ -99,30 +99,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout DE Modules
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: decisionengine_modules
 
       - name: checkout DE Framework
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: decisionengine
           repository: HEPCloud/decisionengine
 
       - name: checkout GlideinWMS for python3
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: glideinwms
           repository: glideinWMS/glideinwms
           ref: branch_v3_9
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
           architecture: "x64"
 
       - name: Cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           # This path is specific to Ubuntu
           path: ~/.cache/pip
@@ -178,5 +178,5 @@ jobs:
     name: Run REUSE to check license compliance
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: fsfe/reuse-action@v1

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   run_flake8:
+    if: ${{ github.ref == 'refs/heads/1.7' }}
     name: Run pytest-flake8 against code tree
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rpm-build.yaml
+++ b/.github/workflows/rpm-build.yaml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   rpmbuild_el7:
+    if: ${{ github.ref == 'refs/heads/1.7' }}
     name: Build an EL7 rpm
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   pytest_el7:
+    if: ${{ github.ref == 'refs/heads/1.7' }}
     runs-on: ubuntu-latest
     name: A job to test the decision engine framework on EL7
     timeout-minutes: 30

--- a/setup.py
+++ b/setup.py
@@ -33,18 +33,17 @@ runtime_require = [
     "requests >= 2.14.2",
     "urllib3 >= 1.26.2",
     "bill-calculator-hep >= 0.1.4",
-    "numpy >= 1.19.5; python_version >= '3.7'",
-    "pandas >= 1.5.3; python_version >= '3.7'",
+    "numpy >= 1.19.5, < 2.0.0; python_version >= '3.7'",
+    "pandas >= 1.5.3, < 2.0.0; python_version >= '3.7'",
     "qcs-api-client >= 0.21.1; python_version >= '3.7'",
 ]
 
 # pull in development requirements
 devel_req = [
-    "pytest >= 6.2.2, < 7.0",  # pytest 7 incompatible with pytest-postgres < 4 from DE
+    "pytest >= 7.0.0, < 8.0",
     "pytest-cov >= 2.11.1",
-    "pytest-flake8 >= 1.0.7",
     "pytest-xdist[psutil] >= 2.3.0",
-    "flake8 >= 4.0.0, < 5.0.0",  # https://github.com/tholo/pytest-flake8/issues/87
+    "flake8 >= 6.0.0, < 7.0.0",
     "coverage >= 6.1.2",
     "tabulate >= 0.8.8",
     "toml >= 0.10.2",
@@ -54,7 +53,7 @@ devel_req = [
     "packaging >= 20.9",
     "wheel >= 0.36.2",
     "pylint >= 2.7.4",
-    "reuse",
+    "reuse >= 1.1.2",
     "importlib_resources >= 5.1.2; python_version <= '3.8'",
 ]
 


### PR DESCRIPTION
Enable tests that run on EL7 only for DE branch 1.7, those are
- run_flake8 in linters.yaml
- rpmbuild_el7 in ci.yaml
- pytest_el7 in pytest.yaml
This is equivalent to what has been done on DE framework

There are updates runtime and devel python module versions in setup.py

an GH action versions have been updated to take care of some deprecation.