### PR TITLE
Fix a typo in glideids_to_advertise

### DIFF
--- a/src/decisionengine_modules/glideinwms/glide_frontend_element.py
+++ b/src/decisionengine_modules/glideinwms/glide_frontend_element.py
@@ -1519,7 +1519,7 @@ class GlideFrontendElementFOM(GlideFrontendElement):
         total_up_stats_arr = init_factory_stats_arr()
         total_down_stats_arr = init_factory_stats_arr()
 
-        for glideid in glideids_to_advertize:
+        for glideid in glideids_to_advertise:
             if glideid == (None, None):
                 # Ignore the unmatched entries
                 continue


### PR DESCRIPTION
Change one occurrence of `glideids_to_advertize` to `glideids_to_advertise`.