### PR TITLE
Do not test external dependencies with flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 [flake8]
   max-line-length = 120
+  # Do not test external dependencies
+  extend-exclude = ./glideinwms,./decisionengine
   # Errors and warnings to ignore
   extend-ignore =
      # line too long (90 > 79 characters)

--- a/.flake8
+++ b/.flake8
@@ -3,7 +3,7 @@
 [flake8]
   max-line-length = 120
   # Do not test external dependencies
-  extend-exclude = ./glideinwms,./decisionengine
+  extend-exclude = ./glideinwms,./decisionengine,./build
   # Errors and warnings to ignore
   extend-ignore =
      # line too long (90 > 79 characters)

--- a/src/decisionengine_modules/glideinwms/tests/test_DEConfigSource.py
+++ b/src/decisionengine_modules/glideinwms/tests/test_DEConfigSource.py
@@ -34,7 +34,7 @@ def test_instantiation(tmp_path):  # noqa: F811
     config_file = tmp_path / "config.json"
     config_file.write_text(GOOD_CONFIG)
     config = DEConfigSource(config_file)
-    assert type(config) == DEConfigSource
+    assert isinstance(config, DEConfigSource)
     assert config["value"] == "foo"
     assert config["list"] == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     assert config["dict"] == {"a": 1, "b": 2, "c": 3}


### PR DESCRIPTION
The entrypoint script we use to run all tests in the container for decisionengine_modules is installing as dependencies `decisionengine` and `GlideinWMS`.
With this PR we exclude these dependencies from flake8 test.
This PR also has an update for an existing test to make it compliant with flake8.