### PR TITLE
New Figure of Merit Metric

### DIFF
--- a/src/decisionengine_modules/glideinwms/transforms/grid_figure_of_merit.py
+++ b/src/decisionengine_modules/glideinwms/transforms/grid_figure_of_merit.py
@@ -37,13 +37,24 @@ class GridFigureOfMerit(Transform.Transform):
                 max_allowed = float(entry["GlideinConfigPerEntryMaxGlideins"])
                 max_idle = float(entry["GlideinConfigPerEntryMaxIdle"])
                 idle = float(entry["GlideinMonitorTotalStatusIdle"])
+               
+                fom_value = figure_of_merit(
+                        self.price_performance, running, max_allowed, idle, max_idle, self.logger
+                )
+
                 f = {
                     ATTR_ENTRYNAME: entry[ATTR_ENTRYNAME],
-                    ATTR_FOM: figure_of_merit(
-                        self.price_performance, running, max_allowed, idle, max_idle, self.logger
-                    ),
+                    ATTR_FOM: fom_value
                 }
                 foms.append(f)
+
+                FIGURE_OF_MERIT_CALCULATION.labels(
+                        performance=self.price_performance,
+                        running=running,
+                        allowed=max_allowed,
+                        idle=idle,
+                        max_idle=max_idle
+                ).set(fom_value)
 
         return {"Grid_Figure_Of_Merit": pandas.DataFrame(foms)}
 

--- a/src/decisionengine_modules/util/figure_of_merit.py
+++ b/src/decisionengine_modules/util/figure_of_merit.py
@@ -6,9 +6,15 @@ Calculate figure of merit
 """
 
 import sys
+from decisionengine.framework.util.metrics import Gauge
 
 _INFINITY = sys.float_info.max
 
+FIGURE_OF_MERIT_CALCULATION = Gauge(
+        "figure_of_merit_calculation",
+        "Figure of Merit Calculation",
+        ["performance", "running", "allowed", "idle", "max_idle"]
+)
 
 def figure_of_merit(performance, running, allowed, idle=None, max_idle=None, logger=None):
     try:
@@ -16,7 +22,15 @@ def figure_of_merit(performance, running, allowed, idle=None, max_idle=None, log
             return _INFINITY
         if idle is not None and max_idle is not None and idle >= max_idle:
             return _INFINITY
-        return performance * float(running + 1) / allowed
+        fom_value = performance * float(running + 1) / allowed
+        FIGURE_OF_MERIT_CALCULATION.labels(
+                performance=performance, 
+                running=running, 
+                allowed=allowed, 
+                idle=idle, 
+                max_idle=max_idle
+        ).set(fom_value)
+        return fom_value
     except TypeError:
         if logger is not None:
             logger.exception("TypeError in figure_of_merit")


### PR DESCRIPTION
Added a new metric that catches figure of merit calculations in "figure_of_merit.py" located in decisionengine_modules/src/decisionengine_modules/util and instrumented "grid_figure_of_merit.py" located in decisionengine_modules/src/decisionengine_modules/glideinwms/transforms