### PR TITLE
Added unit tests for dem_htcondor_slots_status_count, dem_htcondor_cores_count, dem_htcondor_memory_count. Fixed issues in source.py.

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -10,11 +10,8 @@ Source: https://github.com/HEPCloud/decisionengine_modules
 # License: ...
 # SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
-Files: src/*.jsonnet src/*/readme src/*.conf src/*.fixture src/*.csv src/*/AWS/scratch src/*/gce_limits_factory_entries.test src/*/data/monitoring.json src/*/data/passwd src/*/data/expected_metric_values.json
-Copyright: 2017 Fermi Research Alliance, LLC
-License: Apache-2.0
 
-Files: src/*.jsonnet src/*/readme src/*.conf src/*.fixture src/*.csv src/*/AWS/scratch src/*/gce_limits_factory_entries.test src/*/data/monitoring.json src/*/data/passwd
+Files: src/*.jsonnet src/*/readme src/*.conf src/*.fixture src/*.csv src/*/AWS/scratch src/*/gce_limits_factory_entries.test src/*/data/monitoring.json src/*/data/passwd src/*/data/expected_metric_values.json
 Copyright: 2017 Fermi Research Alliance, LLC
 License: Apache-2.0
 

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -10,6 +10,9 @@ Source: https://github.com/HEPCloud/decisionengine_modules
 # License: ...
 # SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
+Files: src/*.jsonnet src/*/readme src/*.conf src/*.fixture src/*.csv src/*/AWS/scratch src/*/gce_limits_factory_entries.test src/*/data/monitoring.json src/*/data/passwd src/*/data/expected_metric_values.json
+Copyright: 2017 Fermi Research Alliance, LLC
+License: Apache-2.0
 
 Files: src/*.jsonnet src/*/readme src/*.conf src/*.fixture src/*.csv src/*/AWS/scratch src/*/gce_limits_factory_entries.test src/*/data/monitoring.json src/*/data/passwd
 Copyright: 2017 Fermi Research Alliance, LLC

--- a/src/decisionengine_modules/htcondor/sources/source.py
+++ b/src/decisionengine_modules/htcondor/sources/source.py
@@ -102,15 +102,10 @@ class ResourceManifests(Source.Source, metaclass=abc.ABCMeta):
 
             condor_status.load(self.constraint, self.classad_attrs, self.condor_config)
             source_statuses = defaultdict(int)
-            source_statuses = defaultdict(int)
             for eachDict in condor_status.stored_data:
                 for key, value in self.correction_map.items():
                     if eachDict.get(key) is None:
                         eachDict[key] = value
-                source_statuses[eachDict["Activity"]] += 1
-
-            for key, value in source_statuses.items():
-                DEM_HTCONDOR_SLOTS_STATUS_COUNT.labels(source_status=key).set(value)
                 source_statuses[eachDict["Activity"]] += 1
 
             for key, value in source_statuses.items():
@@ -147,3 +142,27 @@ class ResourceManifests(Source.Source, metaclass=abc.ABCMeta):
             )
 
         return dataframe
+
+    def get_metric_values(self):
+        """
+        Collect and return the current values of Prometheus metrics.
+        :rtype: dict
+        """
+
+        metric_values = {"slots_status_count": {}, "cores_count": {}, "memory_count": {}}
+
+        metrics = {
+            "slots_status_count": DEM_HTCONDOR_SLOTS_STATUS_COUNT,
+            "cores_count": DEM_HTCONDOR_CORES_COUNT,
+            "memory_count": DEM_HTCONDOR_MEMORY_COUNT,
+        }
+
+        for metric_name, metric in metrics.items():
+            for sample in metric.collect():
+                for sample in sample.samples:
+                    labels = sample.labels
+                    status = labels.get("source_status" if metric_name == "slots_status_count" else "state", "Unknown")
+                    count = sample.value
+                    metric_values[metric_name][status] = count
+
+        return metric_values

--- a/src/decisionengine_modules/tests/data/expected_metric_values.json
+++ b/src/decisionengine_modules/tests/data/expected_metric_values.json
@@ -1,0 +1,29 @@
+{
+  "Slots": {
+    "Idle": 0,
+    "Busy": 1,
+    "Retiring": 1,
+    "Vacating": 0,
+    "Suspended": 0,
+    "Benchmarking": 0,
+    "Killing": 0
+  },
+  "Cores": {
+    "Claimed": 2,
+    "Unclaimed": 0,
+    "Owner": 0,
+    "Matched": 0,
+    "Preempting": 0,
+    "Backfill": 0,
+    "Drained": 0
+  },
+  "Memory": {
+    "Claimed": 3716.0,
+    "Unclaimed": 0,
+    "Owner": 0,
+    "Matched": 0,
+    "Preempting": 0,
+    "Backfill": 0,
+    "Drained": 0
+  }
+}

--- a/src/decisionengine_modules/tests/test_metrics.py
+++ b/src/decisionengine_modules/tests/test_metrics.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+
+from unittest import mock
+
+import pandas
+import pytest
+
+from decisionengine_modules.htcondor import htcondor_query
+from decisionengine_modules.htcondor.sources import source
+from decisionengine_modules.util import testutils as utils
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
+FIXTURE_FILE = os.path.join(DATA_DIR, "cs.fixture")
+EXPECTED_VALUES_FILE = os.path.join(DATA_DIR, "expected_metric_values.json")
+
+
+class MockResourceManifests(source.ResourceManifests):
+    def acquire(self):
+        return pandas.DataFrame()
+
+
+@pytest.fixture
+def source_instance():
+    config = {
+        "channel_name": "test",
+        "condor_config": "condor_config",
+        "collector_host": "fermicloud122.fnal.gov",
+        "classad_attrs": ["ClusterId", "ProcId", "JobStatus"],
+        "group_attr": ["Name"],
+        "subsystem_name": "subsystem_name",
+        "correction_map": {
+            "Activity": "",
+            "Cpus": 0,
+            "GLIDECLIENT_NAME": "",
+            "GLIDEIN_CredentialIdentifier": "",
+            "GLIDEIN_Entry_Name": "",
+            "GLIDEIN_FACTORY": "",
+            "GLIDEIN_GridType": "",
+            "GLIDEIN_Name": "",
+            "GLIDEIN_Resource_Slots": "",
+            "Memory": 0,
+            "PartitionableSlot": 0,
+            "SlotType": "",
+            "State": "",
+            "TotalCpus": 0,
+            "TotalSlotCpus": 0,
+            "TotalSlots": 0,
+        },
+    }
+    return MockResourceManifests(config)
+
+
+@pytest.fixture
+def setup_metrics_dir_for_test(monkeypatch, tmp_path):
+    monkeypatch.setenv("PROMETHEUS_MULTIPROC_DIR", tmp_path)
+
+
+def load_expected_values():
+    with open(EXPECTED_VALUES_FILE) as f:
+        return json.load(f)
+
+
+def test_count_slots(source_instance, setup_metrics_dir_for_test):
+    expected_values = load_expected_values()
+    with mock.patch.object(htcondor_query.CondorStatus, "fetch", return_value=utils.input_from_file(FIXTURE_FILE)):
+        source_instance.load()
+        metric_values = source_instance.get_metric_values()["slots_status_count"]
+        for label, expected_value in expected_values["Slots"].items():
+            assert expected_value == 0 or metric_values[label] == expected_value
+
+
+def test_count_cores(source_instance, setup_metrics_dir_for_test):
+    expected_values = load_expected_values()
+    with mock.patch.object(htcondor_query.CondorStatus, "fetch", return_value=utils.input_from_file(FIXTURE_FILE)):
+        source_instance.load()
+        metric_values = source_instance.get_metric_values()["cores_count"]
+        for label, expected_value in expected_values["Cores"].items():
+            assert expected_value == 0 or metric_values[label] == expected_value
+
+
+def test_count_memory(source_instance, setup_metrics_dir_for_test):
+    expected_values = load_expected_values()
+    with mock.patch.object(htcondor_query.CondorStatus, "fetch", return_value=utils.input_from_file(FIXTURE_FILE)):
+        source_instance.load()
+        metric_values = source_instance.get_metric_values()["memory_count"]
+        for label, expected_value in expected_values["Memory"].items():
+            assert expected_value == 0 or metric_values[label] == expected_value


### PR DESCRIPTION
Unit tests use cs.fixture to mock Condor and check metric values against those in expected_metric_values.json. In source.py, removed extra for loop in load() and added get_metric_values() to retrieve metric values for unit tests.