### PR TITLE
Update Python Unit Tests for GCE Billing

### DIFF
--- a/src/decisionengine_modules/tests/test_GCEBillingInfo.py
+++ b/src/decisionengine_modules/tests/test_GCEBillingInfo.py
@@ -33,21 +33,3 @@ config_billing_info = {
 def test_produces():
     bi_pub = GCEBillingInfo.GCEBillingInfo(config_billing_info)
     assert bi_pub._produces == {"GCE_Billing_Info": pandas.DataFrame}
-
-
-def test_unable_to_download_filelist():
-    constantsDict = {
-        "projectId": "hepcloud-fnal",
-        "credentialsProfileName": "BillingBlah",
-        "accountNumber": 1111,
-        "bucketBillingName": "billing-hepcloud-fnal",
-        "lastKnownBillDate": "10/01/18 00:00",
-        "balanceAtDate": 100.0,
-        "applyDiscount": True,
-    }
-    globalConf = {"graphite_host": "dummy", "graphite_context_billing": "dummy", "outputPath": "."}
-
-    calculator = GCEBillCalculator(None, globalConf, constantsDict, structlog.getLogger())
-
-    file_list = calculator._downloadBillFiles()
-    assert file_list == []

--- a/src/decisionengine_modules/tests/test_GCEBillingInfo.py
+++ b/src/decisionengine_modules/tests/test_GCEBillingInfo.py
@@ -2,9 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pandas
-import structlog
-
-from bill_calculator_hep.GCEBillAnalysis import GCEBillCalculator
 
 from decisionengine_modules.GCE.sources import GCEBillingInfo
 

--- a/src/decisionengine_modules/tests/test_GCEBillingInfo.py
+++ b/src/decisionengine_modules/tests/test_GCEBillingInfo.py
@@ -14,16 +14,11 @@ from decisionengine_modules.GCE.sources import GCEBillingInfo
 # you may be able to mock around this.
 
 config_billing_info = {
-    "channel_name": "Test",
+    "channel_name": "GCETest",
     "projectId": "hepcloud-fnal",
     "lastKnownBillDate": "10/01/18 00:00",  # '%m/%d/%y %H:%M'
     "balanceAtDate": 100.0,  # $
-    "accountName": "None",
-    "accountNumber": 1111,
-    "credentialsProfileName": "BillingBlah",
     "applyDiscount": True,  # DLT discount does not apply to credits
-    "botoConfig": ".boto3",
-    "localFileDir": ".",
 }
 
 


### PR DESCRIPTION
Marco reported that an error was being observed in the unit tests for DE Modules: https://github.com/HEPCloud/decisionengine_modules/actions/runs/13599548609/job/38023217317#step:14:408

Upon closer inspection of the log corresponding to the CI workflow step, the error was being caused due to a KeyError for `sumToDate`. Further looking into the stacktrace revealed that this was originating from a test defined for GCE Billing which was running a test pertaining to downloading of cloud billing files. Taking a closer look at the method being invoked `test_unable_to_download_filelist()`, it looks like that test is specifically intended to download the list of cloud billing files for GCE. However, the download of billing files is no longer relevant since GCE cloud billing has migrated to using BigQuery and the underlying billing calculation logic has been updated in `bill-calculator-hep` module. So, the entire method is obsolete and no longer needed since the download method has been eliminated altogether.

Removing the test for the billing files download revealed unused import statements and certain configuration details in the unit test script that are no longer necessary with GCE Billing with BigQuery. These have been removed as necessary.