### PR TITLE
Update test setup for DE modules

### DIFF
--- a/.Jenkins/workflows/Jenkinsfile_EL9
+++ b/.Jenkins/workflows/Jenkinsfile_EL9
@@ -104,50 +104,6 @@ pipeline {
                             }
                     }
                 }
-                stage('rpmbuild') {
-                    agent {
-                        node {
-                            label 'podman'
-                            customWorkspace "${WORKSPACE}/${STAGE_NAME}"
-                        }
-                    }
-                    options {
-                        timeout(time: "${STAGE_TIMEOUT}", activity: false, unit: 'MINUTES')
-                    }
-                    steps {
-                        script {
-                            // DOCKER_IMAGE is defined through Jenkins project
-                            rpmbuildStageDockerImage="${DOCKER_IMAGE}_${BUILD_NUMBER}_${STAGE_NAME}"
-                        }
-                        echo "cleanup workspace"
-                        sh 'for f in $(ls -A); do rm -rf ${f}; done'
-                        // DE_MOD_REPO is defined through Jenkins project
-                        echo "clone decisionengine_modules code from ${DE_MOD_REPO}"
-                        sh '''
-                            git clone ${DE_MOD_REPO}
-                            cd decisionengine_modules
-                            echo "checkout ${BRANCH} branch"
-                            git checkout ${BRANCH}
-                            echo GITHUB_PR_NUMBER: ${GITHUB_PR_NUMBER} - GITHUB_PR_STATE: ${GITHUB_PR_STATE}
-                            if [[ -n ${GITHUB_PR_NUMBER} && ${GITHUB_PR_STATE} == OPEN ]]; then
-                                git fetch origin pull/${GITHUB_PR_NUMBER}/merge:merge${GITHUB_PR_NUMBER}
-                                git checkout merge${GITHUB_PR_NUMBER}
-                            fi
-                            cd ..
-                        '''
-                        echo "prepare podman image ${rpmbuildStageDockerImage}"
-                        sh "podman build --pull --tag ${rpmbuildStageDockerImage} --build-arg BASEIMAGE=docker.io/hepcloud/decision-engine-ci-el9:${BRANCH} --build-arg UID=\$(id -u) --build-arg GID=\$(id -g) -f decisionengine_modules/package/ci/EL9/Dockerfile decisionengine_modules/package/ci/EL9/"
-                        echo "Run ${STAGE_NAME} tests"
-                        sh "podman run --userns keep-id:uid=\$(id -u),gid=\$(id -g) --rm --env GITHUB_PR_NUMBER=${GITHUB_PR_NUMBER} --env PYTEST_TIMEOUT=${PYTEST_TIMEOUT} -v ${WORKSPACE}/decisionengine_modules:${WORKSPACE}/decisionengine_modules -w ${WORKSPACE}/decisionengine_modules ${rpmbuildStageDockerImage} \"setup.py bdist_rpm\" \"rpmbuild.log\" \"${BRANCH}\""
-                    }
-                    post {
-                        always {
-                            archiveArtifacts artifacts: "decisionengine_modules/rpmbuild.log,decisionengine_modules/dist/*.rpm"
-                            echo "cleanup podman image ${rpmbuildStageDockerImage}"
-                            sh "podman rmi ${rpmbuildStageDockerImage}"
-                        }
-                    }
-                }
             }
         }
     }

--- a/package/ci/EL9/python3-entrypoint.sh
+++ b/package/ci/EL9/python3-entrypoint.sh
@@ -27,7 +27,7 @@ git clone -b ${DE_BRANCH} https://github.com/HEPCloud/decisionengine.git
 
 # checkout GlideinWMS for python3
 rm -rf glideinwms
-git clone -b branch_v3_9 https://github.com/glideinWMS/glideinwms.git
+git clone -b master https://github.com/glideinWMS/glideinwms.git
 
 # Install dependencies for GlideinWMS
 python3 -m pip install --upgrade pip


### PR DESCRIPTION
This PR updates test setup for DE modules to run on Jenkins.
- Use glideinwms master branch to run unit tests;
- In Jenkins pipeline for DE modules we don't need to build RPMs anymore.