### PR TITLE
Remove "glidein_master_name" from metrics labels

### DIFF
--- a/src/decisionengine_modules/glideinwms/transforms/glidein_requests.py
+++ b/src/decisionengine_modules/glideinwms/transforms/glidein_requests.py
@@ -32,15 +32,9 @@ METRICS = {
     "NAME_OF_GROUP": Gauge("de_group_manifests_groupname", "Name of grouup manifest"),
     "REQ_IDLE_GLIDEINS": Gauge("de_req_idle_glideins_total", "Requested minimum idle glideins", ["ce"]),
     "REQ_MAX_GLIDEINS": Gauge("de_req_max_glideins_total", "Requested max glideins", ["ce"]),
-    "TOTAL_SLOTS": Gauge(
-        "de_total_slots", "Total slots available", ["glidein_entry_name", "glidein_site"]
-    ),
-    "TOTAL_SLOT_CPUS": Gauge(
-        "de_total_slot_cpus", "Total cpu slots available", ["glidein_entry_name", "glidein_site"]
-    ),
-    "TOTAL_CPUS": Gauge(
-        "de_total_cpu", "Total CPU available", ["glidein_entry_name", "glidein_site"]
-    ),
+    "TOTAL_SLOTS": Gauge("de_total_slots", "Total slots available", ["glidein_entry_name", "glidein_site"]),
+    "TOTAL_SLOT_CPUS": Gauge("de_total_slot_cpus", "Total cpu slots available", ["glidein_entry_name", "glidein_site"]),
+    "TOTAL_CPUS": Gauge("de_total_cpu", "Total CPU available", ["glidein_entry_name", "glidein_site"]),
     # "MEMORY": Gauge("de_total_memory", "Allocated Memory"),
     # "STATE": Gauge("de_state_slot","State of Slot" ),
     # "ACTIVITY": Gauge("de_stard_manifest_activity", "activity of jobs"),

--- a/src/decisionengine_modules/glideinwms/transforms/glidein_requests.py
+++ b/src/decisionengine_modules/glideinwms/transforms/glidein_requests.py
@@ -33,13 +33,13 @@ METRICS = {
     "REQ_IDLE_GLIDEINS": Gauge("de_req_idle_glideins_total", "Requested minimum idle glideins", ["ce"]),
     "REQ_MAX_GLIDEINS": Gauge("de_req_max_glideins_total", "Requested max glideins", ["ce"]),
     "TOTAL_SLOTS": Gauge(
-        "de_total_slots", "Total slots available", ["glidein_entry_name", "glidein_master_name", "glidein_site"]
+        "de_total_slots", "Total slots available", ["glidein_entry_name", "glidein_site"]
     ),
     "TOTAL_SLOT_CPUS": Gauge(
-        "de_total_slot_cpus", "Total cpu slots available", ["glidein_entry_name", "glidein_master_name", "glidein_site"]
+        "de_total_slot_cpus", "Total cpu slots available", ["glidein_entry_name", "glidein_site"]
     ),
     "TOTAL_CPUS": Gauge(
-        "de_total_cpu", "Total CPU available", ["glidein_entry_name", "glidein_master_name", "glidein_site"]
+        "de_total_cpu", "Total CPU available", ["glidein_entry_name", "glidein_site"]
     ),
     # "MEMORY": Gauge("de_total_memory", "Allocated Memory"),
     # "STATE": Gauge("de_state_slot","State of Slot" ),
@@ -142,17 +142,14 @@ class GlideinRequestManifests(Transform.Transform):
             for row in slots_df_rows:
                 METRICS["TOTAL_CPUS"].labels(
                     glidein_entry_name=row.GLIDEIN_Entry_Name,
-                    glidein_master_name=row.GLIDEIN_MASTER_NAME,
                     glidein_site=row.GLIDEIN_Site,
                 ).set(row.TotalCpus)
                 METRICS["TOTAL_SLOTS"].labels(
                     glidein_entry_name=row.GLIDEIN_Entry_Name,
-                    glidein_master_name=row.GLIDEIN_MASTER_NAME,
                     glidein_site=row.GLIDEIN_Site,
                 ).set(row.TotalSlots)
                 METRICS["TOTAL_SLOT_CPUS"].labels(
                     glidein_entry_name=row.GLIDEIN_Entry_Name,
-                    glidein_master_name=row.GLIDEIN_MASTER_NAME,
                     glidein_site=row.GLIDEIN_Site,
                 ).set(row.TotalSlotCpus)
 


### PR DESCRIPTION
Simple PR to remove glidein_master_name from metrics.  We should not label those in the metrics - if we ever need that info, it should come from the logs.