### PR TITLE
Fix glideclient deadvertising

### DIFF
--- a/src/decisionengine_modules/htcondor/publishers/publisher.py
+++ b/src/decisionengine_modules/htcondor/publishers/publisher.py
@@ -15,7 +15,7 @@ from decisionengine.framework.modules.Publisher import Parameter
 from decisionengine_modules.util.retry_function import retry_wrapper
 
 DEFAULT_UPDATE_AD_COMMAND = "UPDATE_AD_GENERIC"
-DEFAULT_INVALIDATE_AD_COMMAND = "INVALIDATE_AD_GENERIC"
+DEFAULT_INVALIDATE_AD_COMMAND = "INVALIDATE_ADS_GENERIC"
 
 
 @Publisher.supports_config(
@@ -46,7 +46,11 @@ class HTCondorManifests(Publisher.Publisher, metaclass=abc.ABCMeta):
         for collector_host in self.invalidate_ads_constraint:
             constraint = self.invalidate_ads_constraint[collector_host]
             if constraint:
-                ads = [{"MyType": "Query", "TargetType": self.classad_type, "Requirements": constraint}]
+                ad = classad.ClassAd()
+                ad.update(
+                    {"MyType": "Query", "TargetType": self.classad_type, "Requirements": classad.ExprTree(constraint)}
+                )
+                ads = [ad]
                 try:
                     self.logger.info(
                         f"Invalidating {self.classad_type} classads from collector_host {collector_host} with constraint {constraint}"


### PR DESCRIPTION
This pull request fixes the deavertising of glideclients by correcting the invalidate command to `INVALIDATE_ADS_GENERIC` and using the `classad.ExprTree` class to represent the constraint expression.